### PR TITLE
ensure gzip writers are closed before retrieiving gzipped bytes

### DIFF
--- a/sapmhandler/handlers.go
+++ b/sapmhandler/handlers.go
@@ -152,8 +152,8 @@ func NewTraceHandlerV2(receiver func(ctx context.Context, sapm *splunksapm.PostS
 			return
 		}
 
-		// flush gzip writer
-		err = writer.Flush()
+		// close the gzip writer and write gzip footer
+		err = writer.Close()
 		if err != nil {
 			rw.WriteHeader(http.StatusInternalServerError)
 			return

--- a/sapmhandler/handlers_test.go
+++ b/sapmhandler/handlers_test.go
@@ -23,7 +23,6 @@ func TestNewV2TraceHandler(t *testing.T) {
 	var gzippedValidProtobufBuf bytes.Buffer
 	zipper = gzip.NewWriter(&gzippedValidProtobufBuf)
 	zipper.Write(validProto)
-	zipper.Flush()
 	zipper.Close()
 	gzippedValidProtobufReq := httptest.NewRequest(http.MethodPost, path.Join("http://localhost", TraceEndpointV2), bytes.NewReader(gzippedValidProtobufBuf.Bytes()))
 	gzippedValidProtobufReq.Header.Set(contentTypeHeader, xprotobuf)
@@ -46,7 +45,6 @@ func TestNewV2TraceHandler(t *testing.T) {
 	var emptyGZipBuf bytes.Buffer
 	zipper = gzip.NewWriter(&emptyGZipBuf)
 	zipper.Write([]byte{})
-	zipper.Flush()
 	zipper.Close()
 	emptyGZipReq := httptest.NewRequest(http.MethodPost, path.Join("http://localhost", TraceEndpointV2), bytes.NewReader(emptyGZipBuf.Bytes()))
 	emptyGZipReq.Header.Set(contentTypeHeader, xprotobuf)
@@ -55,7 +53,6 @@ func TestNewV2TraceHandler(t *testing.T) {
 	var invalidProtubfBuf bytes.Buffer
 	zipper = gzip.NewWriter(&invalidProtubfBuf)
 	zipper.Write([]byte("invalid protbuf body"))
-	zipper.Flush()
 	zipper.Close()
 	invalidProtobufReq := httptest.NewRequest(http.MethodPost, path.Join("http://localhost", TraceEndpointV2), bytes.NewReader(invalidProtubfBuf.Bytes()))
 	invalidProtobufReq.Header.Set(contentTypeHeader, xprotobuf)


### PR DESCRIPTION
I was misusing the gzip writer.  This pr correctly ensures the writer is closed before the gzipped bytes are used.  This ensures the writer is flushed and the gzip footer is written to the byte buffer.