### PR TITLE
Delegate all types of retries to the caller

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,14 @@
+version: 2
+
+jobs:
+  build:
+    docker:
+      - image: circleci/golang:1.12
+    steps:
+      - checkout
+      - run:
+          name: Install tools
+          command: make install-tools
+      - run:
+          name: Verify
+          command: make check

--- a/client/errors.go
+++ b/client/errors.go
@@ -14,14 +14,14 @@
 
 package client
 
-// ErrHTTPSend is returned by the HTTP sender when it fails to complete a request for any reason.
-type ErrHTTPSend struct {
+// ErrSend is returned by the HTTP sender when it fails to complete a request for any reason.
+type ErrSend struct {
 	Err               error
 	StatusCode        int
 	Permanent         bool
 	RetryDelaySeconds int
 }
 
-func (e *ErrHTTPSend) Error() string {
+func (e *ErrSend) Error() string {
 	return e.Err.Error()
 }

--- a/client/options.go
+++ b/client/options.go
@@ -36,15 +36,6 @@ func WithWorkers(n uint) Option {
 	}
 }
 
-// WithMaxRetries sets a max retries limit on the client. Requests that cannot be completed after this many retries
-// are dropped.
-func WithMaxRetries(n uint) Option {
-	return func(a *Client) error {
-		a.maxRetries = n
-		return nil
-	}
-}
-
 // WithMaxConnections allows to specify the max number of open HTTP connections the client should keep at any time.
 func WithMaxConnections(n uint) Option {
 	return func(a *Client) error {

--- a/client/worker_test.go
+++ b/client/worker_test.go
@@ -49,7 +49,7 @@ var testBatch = &jaegerpb.Batch{
 }
 
 func newTestWorker(c *http.Client) *worker {
-	return newWorker(make(chan struct{}), c, "http://local", "", 0)
+	return newWorker(c, "http://local", "")
 }
 
 func TestPrepare(t *testing.T) {

--- a/makefile
+++ b/makefile
@@ -29,7 +29,7 @@ IMPI=impi
 
 
 .PHONY: all
-all: addlicense fmt impi vet lint goimports misspell staticcheck
+all: check
 	$(MAKE) generate
 	$(MAKE) test
 
@@ -37,6 +37,9 @@ all: addlicense fmt impi vet lint goimports misspell staticcheck
 generate:
 	mkdir -p gen
 	docker run --rm -v $(PWD):$(PWD) -w $(PWD) znly/protoc --gofast_out=./gen/ -I./ -I./vendor/github.com/gogo/protobuf/ -I./vendor/ sapm.proto
+
+.PHONY: check
+check: addlicense fmt impi vet lint goimports misspell staticcheck
 
 .PHONY: test
 test:


### PR DESCRIPTION
Initially the client had full-support for retries but was later removed
in favour of the caller handling them. However, we still left support
for retries in the client for the HTTP 429 case but his is not
really needed in the client. All the client needs to do in this case is
block sending for the time specified the server. The caller can continue
to handle retries for this case like it already does for all other
cases. Another behavioral change this introduces is that it blocks
all workers from sending in case of 429 instead of just the worker
that received the 429 response.
