### PR TITLE
Fix build, golangci-lint installed without pinned version

### DIFF
--- a/makefile
+++ b/makefile
@@ -115,7 +115,6 @@ install-tools:
 	GO111MODULE=on go install \
 	  github.com/google/addlicense \
 	  golang.org/x/lint/golint \
- 	  github.com/golangci/golangci-lint/cmd/golangci-lint \
 	  golang.org/x/tools/cmd/goimports \
 	  github.com/client9/misspell/cmd/misspell \
 	  honnef.co/go/tools/cmd/staticcheck \


### PR DESCRIPTION
The problem was that we install golangci-lint (do not use it) without being present in tools.

Because of this the latest version is installed, which depends on a newer protobuf, which causes
staticcheck errors.

Signed-off-by: Bogdan Drutu <bogdandrutu@gmail.com>