### PR TITLE
Add support to receive OTLP and consume as SAPM

### DIFF
--- a/otlp/attr_to_string.go
+++ b/otlp/attr_to_string.go
@@ -1,0 +1,87 @@
+// Copyright 2019 Splunk, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package otlp
+
+import (
+	"encoding/json"
+
+	otlpcommon "github.com/signalfx/sapm-proto/gen/otlp/common/v1"
+)
+
+// attributeMapToString converts an OTLP AttributeMap to a standard go map
+func attributeMapToString(attrMap *otlpcommon.KeyValueList) string {
+	rawMap := attributeMapToMap(attrMap)
+	js, _ := json.Marshal(rawMap)
+	return string(js)
+}
+
+func attributeArrayToString(attrArray *otlpcommon.ArrayValue) string {
+	rawSlice := attributeArrayToArray(attrArray)
+	js, _ := json.Marshal(rawSlice)
+	return string(js)
+}
+
+func attributeMapToMap(attrMap *otlpcommon.KeyValueList) map[string]interface{} {
+	if attrMap == nil {
+		return nil
+	}
+	rawMap := make(map[string]interface{})
+	for _, attr := range attrMap.GetValues() {
+		switch v := attr.GetValue().GetValue().(type) {
+		case *otlpcommon.AnyValue_StringValue:
+			rawMap[attr.Key] = v.StringValue
+		case *otlpcommon.AnyValue_BoolValue:
+			rawMap[attr.Key] = v.BoolValue
+		case *otlpcommon.AnyValue_IntValue:
+			rawMap[attr.Key] = v.IntValue
+		case *otlpcommon.AnyValue_DoubleValue:
+			rawMap[attr.Key] = v.DoubleValue
+		case *otlpcommon.AnyValue_KvlistValue:
+			rawMap[attr.Key] = attributeMapToMap(v.KvlistValue)
+		case *otlpcommon.AnyValue_ArrayValue:
+			rawMap[attr.Key] = attributeArrayToArray(v.ArrayValue)
+		default:
+			rawMap[attr.Key] = nil
+		}
+	}
+	return rawMap
+}
+
+func attributeArrayToArray(attrArray *otlpcommon.ArrayValue) []interface{} {
+	if attrArray == nil {
+		return nil
+	}
+	rawSlice := make([]interface{}, 0, len(attrArray.Values))
+	for _, attr := range attrArray.GetValues() {
+		switch v := attr.GetValue().(type) {
+		case *otlpcommon.AnyValue_StringValue:
+			rawSlice = append(rawSlice, v.StringValue)
+		case *otlpcommon.AnyValue_BoolValue:
+			rawSlice = append(rawSlice, v.BoolValue)
+		case *otlpcommon.AnyValue_IntValue:
+			rawSlice = append(rawSlice, v.IntValue)
+		case *otlpcommon.AnyValue_DoubleValue:
+			rawSlice = append(rawSlice, v.DoubleValue)
+		case *otlpcommon.AnyValue_KvlistValue:
+			rawSlice = append(rawSlice, "<Invalid array value>")
+		case *otlpcommon.AnyValue_ArrayValue:
+			rawSlice = append(rawSlice, "<Invalid array value>")
+		default:
+			rawSlice = append(rawSlice, nil)
+		}
+	}
+
+	return rawSlice
+}

--- a/otlp/attr_to_string_test.go
+++ b/otlp/attr_to_string_test.go
@@ -1,0 +1,117 @@
+// Copyright 2019 Splunk, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package otlp
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	otlpcommon "github.com/signalfx/sapm-proto/gen/otlp/common/v1"
+)
+
+func TestAttributeMapToString(t *testing.T) {
+	valueMap := &otlpcommon.KeyValueList{
+		Values: []*otlpcommon.KeyValue{
+			{
+				Key: "strKey",
+				Value: &otlpcommon.AnyValue{
+					Value: &otlpcommon.AnyValue_StringValue{
+						StringValue: "strVal",
+					},
+				},
+			},
+			{
+				Key: "intKey",
+				Value: &otlpcommon.AnyValue{
+					Value: &otlpcommon.AnyValue_IntValue{
+						IntValue: 7,
+					},
+				},
+			},
+			{
+				Key: "floatKey",
+				Value: &otlpcommon.AnyValue{
+					Value: &otlpcommon.AnyValue_DoubleValue{
+						DoubleValue: 18.6,
+					},
+				},
+			},
+			{
+				Key: "boolKey",
+				Value: &otlpcommon.AnyValue{
+					Value: &otlpcommon.AnyValue_BoolValue{
+						BoolValue: false,
+					},
+				},
+			},
+			{
+				Key: "nullKey",
+			},
+			{
+				Key: "mapKey",
+				Value: &otlpcommon.AnyValue{
+					Value: &otlpcommon.AnyValue_KvlistValue{
+						KvlistValue: &otlpcommon.KeyValueList{
+							Values: []*otlpcommon.KeyValue{
+								{
+									Key: "keyOne",
+									Value: &otlpcommon.AnyValue{
+										Value: &otlpcommon.AnyValue_StringValue{
+											StringValue: "valOne",
+										},
+									},
+								},
+								{
+									Key: "keyTwo",
+									Value: &otlpcommon.AnyValue{
+										Value: &otlpcommon.AnyValue_StringValue{
+											StringValue: "valTwo",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			{
+				Key: "arrKey",
+				Value: &otlpcommon.AnyValue{
+					Value: &otlpcommon.AnyValue_ArrayValue{
+						ArrayValue: &otlpcommon.ArrayValue{
+							Values: []*otlpcommon.AnyValue{
+								{
+									Value: &otlpcommon.AnyValue_StringValue{
+										StringValue: "strOne",
+									},
+								},
+								{
+									Value: &otlpcommon.AnyValue_StringValue{
+										StringValue: "strTwo",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	expected := `{"arrKey":["strOne","strTwo"],"boolKey":false,"floatKey":18.6,"intKey":7,"mapKey":{"keyOne":"valOne","keyTwo":"valTwo"},"nullKey":null,"strKey":"strVal"}`
+
+	strVal := attributeMapToString(valueMap)
+	assert.EqualValues(t, expected, strVal)
+}

--- a/otlp/constants.go
+++ b/otlp/constants.go
@@ -1,0 +1,49 @@
+// Copyright 2019 Splunk, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package otlp
+
+// Some of the keys used to represent OTLP constructs as tags or annotations in Jaeger.
+const (
+	attributeServiceName = "service.name"
+
+	tagMessage        = "message"
+	tagSpanKind       = "span.kind"
+	tagStatusCode     = "status.code"
+	tagStatusMsg      = "status.message"
+	tagError          = "error"
+	tagHTTPStatusCode = "http.status_code"
+
+	tagW3CTraceState          = "w3c.tracestate"
+	tagInstrumentationName    = "otlp.instrumentation.library.name"
+	tagInstrumentationVersion = "otlp.instrumentation.library.version"
+)
+
+// Constants used for signifying batch-level attribute values where not supplied by OTLP data but required
+// by other protocols.
+const (
+	resourceNotSet        = "OTLPResourceNotSet"
+	resourceNoAttrs       = "OTLPResourceNoAttributes"
+	resourceNoServiceName = "OTLPResourceNoServiceName"
+)
+
+// OpenTracingSpanKind are possible values for tagSpanKind and match the OpenTracing
+// conventions: https://github.com/opentracing/specification/blob/master/semantic_conventions.md
+const (
+	openTracingSpanKindClient   = "client"
+	openTracingSpanKindServer   = "server"
+	openTracingSpanKindConsumer = "consumer"
+	openTracingSpanKindProducer = "producer"
+	openTracingSpanKindInternal = "internal"
+)

--- a/otlp/parser.go
+++ b/otlp/parser.go
@@ -1,0 +1,33 @@
+// Copyright 2019 Splunk, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package otlp
+
+import (
+	"net/http"
+
+	splunksapm "github.com/signalfx/sapm-proto/gen"
+	otlpcoltrace "github.com/signalfx/sapm-proto/gen/otlp/collector/trace/v1"
+	"github.com/signalfx/sapm-proto/sapmprotocol"
+)
+
+// ParseRequest parses from the request (unzip if needed) an OTLP protobuf,
+// and converts it to SAPM.
+func ParseRequest(req *http.Request) (*splunksapm.PostSpansRequest, error) {
+	otlp := otlpcoltrace.ExportTraceServiceRequest{}
+	if err := sapmprotocol.ParseSapmRequest(req, &otlp); err != nil {
+		return nil, err
+	}
+	return otlpToSAPM(otlp)
+}

--- a/otlp/translator.go
+++ b/otlp/translator.go
@@ -1,0 +1,466 @@
+// Copyright 2019 Splunk, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package otlp
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/jaegertracing/jaeger/model"
+
+	splunksapm "github.com/signalfx/sapm-proto/gen"
+	otlpcoltrace "github.com/signalfx/sapm-proto/gen/otlp/collector/trace/v1"
+	otlpcommon "github.com/signalfx/sapm-proto/gen/otlp/common/v1"
+	otlpresource "github.com/signalfx/sapm-proto/gen/otlp/resource/v1"
+	otlptrace "github.com/signalfx/sapm-proto/gen/otlp/trace/v1"
+)
+
+// otlpToSAPM translates otlp trace proto into the SAPM Proto.
+func otlpToSAPM(td otlpcoltrace.ExportTraceServiceRequest) (*splunksapm.PostSpansRequest, error) {
+	sapm := &splunksapm.PostSpansRequest{}
+	if len(td.ResourceSpans) == 0 {
+		return sapm, nil
+	}
+
+	sapm.Batches = make([]*model.Batch, 0, len(td.ResourceSpans))
+
+	for _, rs := range td.ResourceSpans {
+		batch, err := resourceSpansToJaegerProto(rs)
+		if err != nil {
+			return sapm, err
+		}
+		if batch != nil {
+			sapm.Batches = append(sapm.Batches, batch)
+		}
+	}
+
+	return sapm, nil
+}
+
+func resourceSpansToJaegerProto(rs *otlptrace.ResourceSpans) (*model.Batch, error) {
+	if rs == nil {
+		return nil, nil
+	}
+
+	ilss := rs.InstrumentationLibrarySpans
+	if len(ilss) == 0 {
+		return nil, nil
+	}
+
+	batch := &model.Batch{
+		Process: resourceToJaegerProtoProcess(rs.Resource),
+	}
+
+	// Approximate the number of the spans.
+	jSpans := make([]*model.Span, 0, spanCount(ilss))
+
+	for _, ils := range ilss {
+		if ils == nil {
+			continue
+		}
+
+		spans := ils.Spans
+		for _, span := range spans {
+			if span == nil {
+				continue
+			}
+
+			jSpan, err := spanToJaegerProto(span, ils.InstrumentationLibrary)
+			if err != nil {
+				return nil, err
+			}
+			if jSpan != nil {
+				jSpans = append(jSpans, jSpan)
+			}
+		}
+	}
+
+	batch.Spans = jSpans
+
+	return batch, nil
+}
+
+func spanCount(ilss []*otlptrace.InstrumentationLibrarySpans) int {
+	sCount := 0
+	for _, ils := range ilss {
+		if ils == nil {
+			continue
+		}
+		sCount += len(ils.Spans)
+	}
+	return sCount
+}
+
+func resourceToJaegerProtoProcess(resource *otlpresource.Resource) *model.Process {
+	process := model.Process{}
+	if resource == nil {
+		process.ServiceName = resourceNotSet
+		return &process
+	}
+
+	attrs := resource.Attributes
+	if len(attrs) == 0 {
+		process.ServiceName = resourceNoAttrs
+		return &process
+	}
+
+	var serviceName string
+	process.Tags, serviceName = appendTagsFromResourceAttributes(attrs)
+	process.ServiceName = serviceName
+	return &process
+
+}
+
+func appendTagsFromResourceAttributes(attrs []*otlpcommon.KeyValue) ([]model.KeyValue, string) {
+	serviceName := resourceNoServiceName
+	if len(attrs) == 0 {
+		return nil, serviceName
+	}
+
+	tags := make([]model.KeyValue, 0, len(attrs))
+	for _, kv := range attrs {
+		if kv.GetKey() == attributeServiceName {
+			serviceName = kv.GetValue().GetStringValue()
+			continue
+		}
+		tags = append(tags, attributeToJaegerProtoTag(kv.GetKey(), kv.GetValue()))
+	}
+	return tags, serviceName
+}
+
+func appendTagsFromAttributes(dest []model.KeyValue, attrs []*otlpcommon.KeyValue) []model.KeyValue {
+	if len(attrs) == 0 {
+		return dest
+	}
+	for _, kv := range attrs {
+		dest = append(dest, attributeToJaegerProtoTag(kv.Key, kv.Value))
+	}
+	return dest
+}
+
+func attributeToJaegerProtoTag(key string, attr *otlpcommon.AnyValue) model.KeyValue {
+	tag := model.KeyValue{Key: key}
+	switch v := attr.GetValue().(type) {
+	case *otlpcommon.AnyValue_StringValue:
+		// Jaeger-to-Internal maps binary tags to string attributes and encodes them as
+		// base64 strings. Blindingly attempting to decode base64 seems too much.
+		tag.VType = model.ValueType_STRING
+		tag.VStr = v.StringValue
+	case *otlpcommon.AnyValue_BoolValue:
+		tag.VType = model.ValueType_BOOL
+		tag.VBool = v.BoolValue
+	case *otlpcommon.AnyValue_IntValue:
+		tag.VType = model.ValueType_INT64
+		tag.VInt64 = v.IntValue
+	case *otlpcommon.AnyValue_DoubleValue:
+		tag.VType = model.ValueType_FLOAT64
+		tag.VFloat64 = v.DoubleValue
+	case *otlpcommon.AnyValue_KvlistValue:
+		tag.VType = model.ValueType_STRING
+		tag.VStr = attributeMapToString(v.KvlistValue)
+	case *otlpcommon.AnyValue_ArrayValue:
+		tag.VType = model.ValueType_STRING
+		tag.VStr = attributeArrayToString(v.ArrayValue)
+	}
+	return tag
+}
+
+func spanToJaegerProto(span *otlptrace.Span, instLibrary *otlpcommon.InstrumentationLibrary) (*model.Span, error) {
+	if span == nil {
+		return nil, nil
+	}
+
+	traceID, err := model.TraceIDFromBytes(span.TraceId)
+	if err != nil {
+		return nil, err
+	}
+
+	spanID, err := model.SpanIDFromBytes(span.SpanId)
+	if err != nil {
+		return nil, err
+	}
+
+	jReferences, err := makeJaegerProtoReferences(span.Links, span.ParentSpanId, traceID)
+	if err != nil {
+		return nil, fmt.Errorf("error converting span links to Jaeger references: %w", err)
+	}
+
+	startTime := unixNanoToTime(span.StartTimeUnixNano)
+
+	return &model.Span{
+		TraceID:       traceID,
+		SpanID:        spanID,
+		OperationName: span.Name,
+		References:    jReferences,
+		StartTime:     startTime,
+		Duration:      unixNanoToTime(span.EndTimeUnixNano).Sub(startTime),
+		Tags:          getJaegerProtoSpanTags(span, instLibrary),
+		Logs:          spanEventsToJaegerProtoLogs(span.Events),
+	}, nil
+}
+
+func getJaegerProtoSpanTags(span *otlptrace.Span, instLibrary *otlpcommon.InstrumentationLibrary) []model.KeyValue {
+	var spanKindTag, statusCodeTag, errorTag, statusMsgTag model.KeyValue
+	var spanKindTagFound, statusCodeTagFound, errorTagFound, statusMsgTagFound bool
+
+	libraryTags, libraryTagsFound := getTagsFromInstrumentationLibrary(instLibrary)
+
+	tagsCount := len(span.Attributes) + len(libraryTags)
+
+	spanKindTag, spanKindTagFound = getTagFromSpanKind(span.Kind)
+	if spanKindTagFound {
+		tagsCount++
+	}
+	status := span.Status
+	if status != nil {
+		statusCodeTag, statusCodeTagFound = getTagFromStatusCode(status.Code)
+		if statusCodeTagFound {
+			tagsCount++
+		}
+
+		errorTag, errorTagFound = getErrorTagFromStatusCode(status.Code)
+		if errorTagFound {
+			tagsCount++
+		}
+
+		statusMsgTag, statusMsgTagFound = getTagFromStatusMsg(status.Message)
+		if statusMsgTagFound {
+			tagsCount++
+		}
+	}
+
+	traceStateTags, traceStateTagsFound := getTagFromTraceState(span.TraceState)
+	if traceStateTagsFound {
+		tagsCount++
+	}
+
+	if tagsCount == 0 {
+		return nil
+	}
+
+	tags := make([]model.KeyValue, 0, tagsCount)
+	if libraryTagsFound {
+		tags = append(tags, libraryTags...)
+	}
+	tags = appendTagsFromAttributes(tags, span.Attributes)
+	if spanKindTagFound {
+		tags = append(tags, spanKindTag)
+	}
+	if statusCodeTagFound {
+		tags = append(tags, statusCodeTag)
+	}
+	if errorTagFound {
+		tags = append(tags, errorTag)
+	}
+	if statusMsgTagFound {
+		tags = append(tags, statusMsgTag)
+	}
+	if traceStateTagsFound {
+		tags = append(tags, traceStateTags)
+	}
+	return tags
+}
+
+// makeJaegerProtoReferences constructs jaeger span references based on parent span ID and span links
+func makeJaegerProtoReferences(links []*otlptrace.Span_Link, parentSpanID []byte, traceID model.TraceID) ([]model.SpanRef, error) {
+	parentSpanIDSet := len(parentSpanID) != 0
+	if !parentSpanIDSet && len(links) == 0 {
+		return nil, nil
+	}
+
+	refsCount := len(links)
+	if parentSpanIDSet {
+		refsCount++
+	}
+
+	refs := make([]model.SpanRef, 0, refsCount)
+
+	// Put parent span ID at the first place because usually backends look for it
+	// as the first CHILD_OF item in the model.SpanRef slice.
+	if parentSpanIDSet {
+		jParentSpanID, err := model.SpanIDFromBytes(parentSpanID)
+		if err != nil {
+			return nil, fmt.Errorf("incorrect parent span ID: %v", err)
+		}
+
+		refs = append(refs, model.SpanRef{
+			TraceID: traceID,
+			SpanID:  jParentSpanID,
+			RefType: model.SpanRefType_CHILD_OF,
+		})
+	}
+
+	for _, link := range links {
+		if link == nil {
+			continue
+		}
+
+		traceID, err := model.TraceIDFromBytes(link.TraceId)
+		if err != nil {
+			continue // skip invalid link
+		}
+
+		spanID, err := model.SpanIDFromBytes(link.SpanId)
+		if err != nil {
+			continue // skip invalid link
+		}
+
+		refs = append(refs, model.SpanRef{
+			TraceID: traceID,
+			SpanID:  spanID,
+
+			// Since Jaeger RefType is not captured in internal data,
+			// use SpanRefType_FOLLOWS_FROM by default.
+			// SpanRefType_CHILD_OF supposed to be set only from parentSpanID.
+			RefType: model.SpanRefType_FOLLOWS_FROM,
+		})
+	}
+
+	return refs, nil
+}
+
+func spanEventsToJaegerProtoLogs(events []*otlptrace.Span_Event) []model.Log {
+	if len(events) == 0 {
+		return nil
+	}
+
+	logs := make([]model.Log, 0, len(events))
+	for _, event := range events {
+		if event == nil {
+			continue
+		}
+
+		hasName := event.Name != ""
+		fieldsCount := len(event.Attributes)
+		if hasName {
+			fieldsCount++
+		}
+
+		fields := make([]model.KeyValue, 0, fieldsCount)
+		if hasName {
+			fields = append(fields, model.KeyValue{
+				Key:   tagMessage,
+				VType: model.ValueType_STRING,
+				VStr:  event.Name,
+			})
+		}
+		fields = appendTagsFromAttributes(fields, event.Attributes)
+		logs = append(logs, model.Log{
+			Timestamp: unixNanoToTime(event.TimeUnixNano),
+			Fields:    fields,
+		})
+	}
+
+	return logs
+}
+
+func getTagFromSpanKind(spanKind otlptrace.Span_SpanKind) (model.KeyValue, bool) {
+	var tagStr string
+	switch spanKind {
+	case otlptrace.Span_SPAN_KIND_CLIENT:
+		tagStr = string(openTracingSpanKindClient)
+	case otlptrace.Span_SPAN_KIND_SERVER:
+		tagStr = string(openTracingSpanKindServer)
+	case otlptrace.Span_SPAN_KIND_PRODUCER:
+		tagStr = string(openTracingSpanKindProducer)
+	case otlptrace.Span_SPAN_KIND_CONSUMER:
+		tagStr = string(openTracingSpanKindConsumer)
+	case otlptrace.Span_SPAN_KIND_INTERNAL:
+		tagStr = string(openTracingSpanKindInternal)
+	default:
+		return model.KeyValue{}, false
+	}
+
+	return model.KeyValue{
+		Key:   tagSpanKind,
+		VType: model.ValueType_STRING,
+		VStr:  tagStr,
+	}, true
+}
+
+func getTagFromStatusCode(statusCode otlptrace.Status_StatusCode) (model.KeyValue, bool) {
+	return model.KeyValue{
+		Key:    tagStatusCode,
+		VInt64: int64(statusCode),
+		VType:  model.ValueType_INT64,
+	}, true
+}
+
+func getErrorTagFromStatusCode(statusCode otlptrace.Status_StatusCode) (model.KeyValue, bool) {
+	if statusCode == otlptrace.Status_STATUS_CODE_OK {
+		return model.KeyValue{}, false
+	}
+	return model.KeyValue{
+		Key:   tagError,
+		VBool: true,
+		VType: model.ValueType_BOOL,
+	}, true
+}
+
+func getTagFromStatusMsg(statusMsg string) (model.KeyValue, bool) {
+	if statusMsg == "" {
+		return model.KeyValue{}, false
+	}
+	return model.KeyValue{
+		Key:   tagStatusMsg,
+		VStr:  statusMsg,
+		VType: model.ValueType_STRING,
+	}, true
+}
+
+func getTagFromTraceState(traceState string) (model.KeyValue, bool) {
+	if traceState != "" {
+		// TODO Bring this inline with solution for jaegertracing/jaeger-client-java #702 once available
+		return model.KeyValue{
+			Key:   tagW3CTraceState,
+			VStr:  traceState,
+			VType: model.ValueType_STRING,
+		}, true
+	}
+	return model.KeyValue{}, false
+}
+
+func getTagsFromInstrumentationLibrary(il *otlpcommon.InstrumentationLibrary) ([]model.KeyValue, bool) {
+	var keyValues []model.KeyValue
+	if il == nil {
+		return keyValues, false
+	}
+	if il.Name != "" {
+		kv := model.KeyValue{
+			Key:   tagInstrumentationName,
+			VStr:  il.Name,
+			VType: model.ValueType_STRING,
+		}
+		keyValues = append(keyValues, kv)
+	}
+	if il.Version != "" {
+		kv := model.KeyValue{
+			Key:   tagInstrumentationVersion,
+			VStr:  il.Version,
+			VType: model.ValueType_STRING,
+		}
+		keyValues = append(keyValues, kv)
+	}
+
+	return keyValues, true
+}
+
+func unixNanoToTime(t uint64) time.Time {
+	// 0 is a special case and want to make sure we return a time that IsZero() returns true.
+	if t == 0 {
+		return time.Time{}
+	}
+	return time.Unix(0, int64(t)).UTC()
+}

--- a/otlp/translator_test.go
+++ b/otlp/translator_test.go
@@ -1,0 +1,823 @@
+// Copyright 2019 Splunk, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package otlp
+
+import (
+	"encoding/binary"
+	"testing"
+	"time"
+
+	"github.com/jaegertracing/jaeger/model"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	splunksapm "github.com/signalfx/sapm-proto/gen"
+	otlpcoltrace "github.com/signalfx/sapm-proto/gen/otlp/collector/trace/v1"
+	otlpcommon "github.com/signalfx/sapm-proto/gen/otlp/common/v1"
+	otlpresource "github.com/signalfx/sapm-proto/gen/otlp/resource/v1"
+	otlptrace "github.com/signalfx/sapm-proto/gen/otlp/trace/v1"
+)
+
+// Use timespamp with microsecond granularity to work well with jaeger thrift translation
+var (
+	testSpanStartTime      = time.Date(2020, 2, 11, 20, 26, 12, 321000, time.UTC)
+	testSpanStartTimestamp = testSpanStartTime.UnixNano()
+	testSpanEventTime      = time.Date(2020, 2, 11, 20, 26, 13, 123000, time.UTC)
+	testSpanEventTimestamp = testSpanEventTime.UnixNano()
+	testSpanEndTime        = time.Date(2020, 2, 11, 20, 26, 13, 789000, time.UTC)
+	testSpanEndTimestamp   = testSpanEndTime.UnixNano()
+)
+
+func TestGetTagFromStatusCode(t *testing.T) {
+	tests := []struct {
+		name string
+		code otlptrace.Status_StatusCode
+		tag  model.KeyValue
+	}{
+		{
+			name: "ok",
+			code: otlptrace.Status_STATUS_CODE_OK,
+			tag: model.KeyValue{
+				Key:    tagStatusCode,
+				VInt64: int64(otlptrace.Status_STATUS_CODE_OK),
+				VType:  model.ValueType_INT64,
+			},
+		},
+
+		{
+			name: "unknown",
+			code: otlptrace.Status_STATUS_CODE_UNKNOWN_ERROR,
+			tag: model.KeyValue{
+				Key:    tagStatusCode,
+				VInt64: int64(otlptrace.Status_STATUS_CODE_UNKNOWN_ERROR),
+				VType:  model.ValueType_INT64,
+			},
+		},
+
+		{
+			name: "not-found",
+			code: otlptrace.Status_STATUS_CODE_NOT_FOUND,
+			tag: model.KeyValue{
+				Key:    tagStatusCode,
+				VInt64: int64(otlptrace.Status_STATUS_CODE_NOT_FOUND),
+				VType:  model.ValueType_INT64,
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got, ok := getTagFromStatusCode(test.code)
+			assert.True(t, ok)
+			assert.EqualValues(t, test.tag, got)
+		})
+	}
+}
+
+func TestGetErrorTagFromStatusCode(t *testing.T) {
+	errTag := model.KeyValue{
+		Key:   tagError,
+		VBool: true,
+		VType: model.ValueType_BOOL,
+	}
+
+	_, ok := getErrorTagFromStatusCode(otlptrace.Status_STATUS_CODE_OK)
+	assert.False(t, ok)
+
+	got, ok := getErrorTagFromStatusCode(otlptrace.Status_STATUS_CODE_UNKNOWN_ERROR)
+	assert.True(t, ok)
+	assert.EqualValues(t, errTag, got)
+
+	got, ok = getErrorTagFromStatusCode(otlptrace.Status_STATUS_CODE_NOT_FOUND)
+	assert.True(t, ok)
+	assert.EqualValues(t, errTag, got)
+}
+
+func TestGetTagFromStatusMsg(t *testing.T) {
+	got, ok := getTagFromStatusMsg("")
+	assert.False(t, ok)
+
+	got, ok = getTagFromStatusMsg("test-error")
+	assert.True(t, ok)
+	assert.EqualValues(t, model.KeyValue{
+		Key:   tagStatusMsg,
+		VStr:  "test-error",
+		VType: model.ValueType_STRING,
+	}, got)
+}
+
+func TestGetTagFromSpanKind(t *testing.T) {
+	tests := []struct {
+		name string
+		kind otlptrace.Span_SpanKind
+		tag  model.KeyValue
+		ok   bool
+	}{
+		{
+			name: "unspecified",
+			kind: otlptrace.Span_SPAN_KIND_UNSPECIFIED,
+			tag:  model.KeyValue{},
+			ok:   false,
+		},
+
+		{
+			name: "client",
+			kind: otlptrace.Span_SPAN_KIND_CLIENT,
+			tag: model.KeyValue{
+				Key:   tagSpanKind,
+				VType: model.ValueType_STRING,
+				VStr:  string(openTracingSpanKindClient),
+			},
+			ok: true,
+		},
+
+		{
+			name: "server",
+			kind: otlptrace.Span_SPAN_KIND_SERVER,
+			tag: model.KeyValue{
+				Key:   tagSpanKind,
+				VType: model.ValueType_STRING,
+				VStr:  string(openTracingSpanKindServer),
+			},
+			ok: true,
+		},
+
+		{
+			name: "producer",
+			kind: otlptrace.Span_SPAN_KIND_PRODUCER,
+			tag: model.KeyValue{
+				Key:   tagSpanKind,
+				VType: model.ValueType_STRING,
+				VStr:  string(openTracingSpanKindProducer),
+			},
+			ok: true,
+		},
+
+		{
+			name: "consumer",
+			kind: otlptrace.Span_SPAN_KIND_CONSUMER,
+			tag: model.KeyValue{
+				Key:   tagSpanKind,
+				VType: model.ValueType_STRING,
+				VStr:  string(openTracingSpanKindConsumer),
+			},
+			ok: true,
+		},
+
+		{
+			name: "internal",
+			kind: otlptrace.Span_SPAN_KIND_INTERNAL,
+			tag: model.KeyValue{
+				Key:   tagSpanKind,
+				VType: model.ValueType_STRING,
+				VStr:  string(openTracingSpanKindInternal),
+			},
+			ok: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got, ok := getTagFromSpanKind(test.kind)
+			assert.Equal(t, test.ok, ok)
+			assert.EqualValues(t, test.tag, got)
+		})
+	}
+}
+
+func TestAttributesToJaegerProtoTags(t *testing.T) {
+	attributes := []*otlpcommon.KeyValue{
+		{
+			Key: "bool-val",
+			Value: &otlpcommon.AnyValue{
+				Value: &otlpcommon.AnyValue_BoolValue{
+					BoolValue: true,
+				},
+			},
+		},
+		{
+			Key: "int-val",
+			Value: &otlpcommon.AnyValue{
+				Value: &otlpcommon.AnyValue_IntValue{
+					IntValue: 123,
+				},
+			},
+		},
+		{
+			Key: "string-val",
+			Value: &otlpcommon.AnyValue{
+				Value: &otlpcommon.AnyValue_StringValue{
+					StringValue: "abc",
+				},
+			},
+		},
+		{
+			Key: "double-val",
+			Value: &otlpcommon.AnyValue{
+				Value: &otlpcommon.AnyValue_DoubleValue{
+					DoubleValue: 1.23,
+				},
+			},
+		},
+		{
+			Key: attributeServiceName,
+			Value: &otlpcommon.AnyValue{
+				Value: &otlpcommon.AnyValue_StringValue{
+					StringValue: "service-name",
+				},
+			},
+		},
+	}
+
+	expected := []model.KeyValue{
+		{
+			Key:   "bool-val",
+			VType: model.ValueType_BOOL,
+			VBool: true,
+		},
+		{
+			Key:    "int-val",
+			VType:  model.ValueType_INT64,
+			VInt64: 123,
+		},
+		{
+			Key:   "string-val",
+			VType: model.ValueType_STRING,
+			VStr:  "abc",
+		},
+		{
+			Key:      "double-val",
+			VType:    model.ValueType_FLOAT64,
+			VFloat64: 1.23,
+		},
+		{
+			Key:   attributeServiceName,
+			VType: model.ValueType_STRING,
+			VStr:  "service-name",
+		},
+	}
+
+	gotTags := appendTagsFromAttributes(make([]model.KeyValue, 0, len(expected)), attributes)
+	require.EqualValues(t, expected, gotTags)
+
+	// The last item in expected ("service-name") must be skipped in resource tags translation
+	gotResourceTags, getServiceName := appendTagsFromResourceAttributes(attributes)
+	require.EqualValues(t, expected[:4], gotResourceTags)
+	require.EqualValues(t, "service-name", getServiceName)
+}
+
+func TestInternalTracesToJaegerProto(t *testing.T) {
+	tests := []struct {
+		name string
+		td   otlpcoltrace.ExportTraceServiceRequest
+		jb   splunksapm.PostSpansRequest
+		err  error
+	}{
+		{
+			name: "empty",
+			td: otlpcoltrace.ExportTraceServiceRequest{
+				ResourceSpans: []*otlptrace.ResourceSpans(nil),
+			},
+			err: nil,
+		},
+
+		{
+			name: "no-spans",
+			td: otlpcoltrace.ExportTraceServiceRequest{
+				ResourceSpans: []*otlptrace.ResourceSpans{
+					{
+						Resource: generateOtlpResource(),
+					},
+				},
+			},
+			jb: splunksapm.PostSpansRequest{
+				Batches: []*model.Batch{},
+			},
+			err: nil,
+		},
+
+		{
+			name: "no-resource-attrs",
+			td: otlpcoltrace.ExportTraceServiceRequest{
+				ResourceSpans: []*otlptrace.ResourceSpans{
+					{
+						Resource: &otlpresource.Resource{},
+						InstrumentationLibrarySpans: []*otlptrace.InstrumentationLibrarySpans{
+							{
+								Spans: []*otlptrace.Span{
+									generateOtlpSpan(),
+								},
+							},
+						},
+					},
+				},
+			},
+			jb: splunksapm.PostSpansRequest{
+				Batches: []*model.Batch{
+					{
+						Process: &model.Process{
+							ServiceName: resourceNoAttrs,
+						},
+						Spans: []*model.Span{
+							generateProtoSpan(),
+						},
+					},
+				},
+			},
+			err: nil,
+		},
+		{
+			name: "one-span-with-trace-state",
+			td: otlpcoltrace.ExportTraceServiceRequest{
+				ResourceSpans: []*otlptrace.ResourceSpans{
+					{
+						InstrumentationLibrarySpans: []*otlptrace.InstrumentationLibrarySpans{
+							{
+								Spans: []*otlptrace.Span{
+									generateOtlpSpanWithTraceState(),
+								},
+							},
+						},
+					},
+				},
+			},
+			jb: splunksapm.PostSpansRequest{
+				Batches: []*model.Batch{
+					{
+						Process: &model.Process{
+							ServiceName: resourceNotSet,
+						},
+						Spans: []*model.Span{
+							generateProtoSpanWithTraceState(),
+						},
+					},
+				},
+			},
+			err: nil,
+		},
+		{
+			name: "library-info",
+			td: otlpcoltrace.ExportTraceServiceRequest{
+				ResourceSpans: []*otlptrace.ResourceSpans{
+					{
+						InstrumentationLibrarySpans: []*otlptrace.InstrumentationLibrarySpans{
+							{
+								InstrumentationLibrary: &otlpcommon.InstrumentationLibrary{
+									Name:    "io.opentelemetry.test",
+									Version: "0.42.0",
+								},
+								Spans: []*otlptrace.Span{
+									generateOtlpSpan(),
+								},
+							},
+						},
+					},
+				},
+			},
+			jb: splunksapm.PostSpansRequest{
+				Batches: []*model.Batch{
+					{
+						Process: &model.Process{
+							ServiceName: resourceNotSet,
+						},
+						Spans: []*model.Span{
+							generateProtoSpanWithLibraryInfo("io.opentelemetry.test"),
+						},
+					},
+				},
+			},
+			err: nil,
+		},
+		{
+			name: "two-spans-child-parent",
+			td: otlpcoltrace.ExportTraceServiceRequest{
+				ResourceSpans: []*otlptrace.ResourceSpans{
+					{
+						Resource: generateOtlpResource(),
+						InstrumentationLibrarySpans: []*otlptrace.InstrumentationLibrarySpans{
+							{
+								Spans: []*otlptrace.Span{
+									generateOtlpSpan(),
+									generateOtlpChildSpan(),
+								},
+							},
+						},
+					},
+				},
+			},
+			jb: splunksapm.PostSpansRequest{
+				Batches: []*model.Batch{
+					{
+						Process: generateProtoProcess(),
+						Spans: []*model.Span{
+							generateProtoSpan(),
+							generateProtoChildSpanWithErrorTags(),
+						},
+					},
+				},
+			},
+			err: nil,
+		},
+
+		{
+			name: "two-spans-with-follower",
+			td: otlpcoltrace.ExportTraceServiceRequest{
+				ResourceSpans: []*otlptrace.ResourceSpans{
+					{
+						Resource: generateOtlpResource(),
+						InstrumentationLibrarySpans: []*otlptrace.InstrumentationLibrarySpans{
+							{
+								Spans: []*otlptrace.Span{
+									generateOtlpSpan(),
+									generateOtlpFollowerSpan(),
+								},
+							},
+						},
+					},
+				},
+			},
+			jb: splunksapm.PostSpansRequest{
+				Batches: []*model.Batch{
+					{
+						Process: generateProtoProcess(),
+						Spans: []*model.Span{
+							generateProtoSpan(),
+							generateProtoFollowerSpan(),
+						},
+					},
+				},
+			},
+			err: nil,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			jbs, err := otlpToSAPM(test.td)
+			assert.EqualValues(t, test.err, err)
+
+			if len(test.jb.Batches) > 0 {
+				assert.EqualValues(t, test.jb.Batches[0], jbs.Batches[0])
+				assert.EqualValues(t, test.jb.Batches[0].Process, jbs.Batches[0].Process)
+				assert.EqualValues(t, test.jb.Batches[0].Spans, jbs.Batches[0].Spans)
+				if len(test.jb.Batches[0].Spans) >= 1 {
+					assert.EqualValues(t, test.jb.Batches[0].Spans[0], jbs.Batches[0].Spans[0])
+					assert.EqualValues(t, test.jb.Batches[0].Spans[0].References, jbs.Batches[0].Spans[0].References)
+					assert.EqualValues(t, test.jb.Batches[0].Spans[0].Logs, jbs.Batches[0].Spans[0].Logs)
+					assert.EqualValues(t, test.jb.Batches[0].Spans[0].Tags, jbs.Batches[0].Spans[0].Tags)
+				}
+				if len(test.jb.Batches[0].Spans) >= 2 {
+					assert.EqualValues(t, test.jb.Batches[0].Spans[1], jbs.Batches[0].Spans[1])
+					assert.EqualValues(t, test.jb.Batches[0].Spans[1].References, jbs.Batches[0].Spans[1].References)
+					assert.EqualValues(t, test.jb.Batches[0].Spans[1].Logs, jbs.Batches[0].Spans[1].Logs)
+					assert.EqualValues(t, test.jb.Batches[0].Spans[1].Tags, jbs.Batches[0].Spans[1].Tags)
+				}
+				test.jb.Batches[0].Spans = nil
+				jbs.Batches[0].Spans = nil
+				assert.EqualValues(t, test.jb.Batches[0], jbs.Batches[0])
+			}
+			assert.EqualValues(t, &test.jb, jbs)
+		})
+	}
+}
+
+func generateProtoChildSpanWithErrorTags() *model.Span {
+	span := generateProtoChildSpan()
+	span.Tags = append(span.Tags, model.KeyValue{
+		Key:    tagStatusCode,
+		VType:  model.ValueType_INT64,
+		VInt64: int64(otlptrace.Status_STATUS_CODE_NOT_FOUND),
+	})
+	span.Tags = append(span.Tags, model.KeyValue{
+		Key:   tagError,
+		VBool: true,
+		VType: model.ValueType_BOOL,
+	})
+	return span
+}
+
+func BenchmarkInternalTracesToJaegerProto(b *testing.B) {
+	td := otlpcoltrace.ExportTraceServiceRequest{
+		ResourceSpans: []*otlptrace.ResourceSpans{
+			{
+				Resource: generateOtlpResource(),
+				InstrumentationLibrarySpans: []*otlptrace.InstrumentationLibrarySpans{
+					{
+						Spans: []*otlptrace.Span{
+							generateOtlpSpan(),
+							generateOtlpFollowerSpan(),
+						},
+					},
+				},
+			},
+		},
+	}
+
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		_, err := otlpToSAPM(td)
+		assert.NoError(b, err)
+	}
+}
+
+func generateProtoProcess() *model.Process {
+	return &model.Process{
+		ServiceName: "service",
+		Tags: []model.KeyValue{
+			{
+				Key:    "int-attr",
+				VType:  model.ValueType_INT64,
+				VInt64: 123,
+			},
+		},
+	}
+}
+
+func generateProtoSpan() *model.Span {
+	return &model.Span{
+		TraceID: model.NewTraceID(
+			binary.BigEndian.Uint64([]byte{0xF1, 0xF2, 0xF3, 0xF4, 0xF5, 0xF6, 0xF7, 0xF8}),
+			binary.BigEndian.Uint64([]byte{0xF9, 0xFA, 0xFB, 0xFC, 0xFD, 0xFE, 0xFF, 0x80}),
+		),
+		SpanID:        model.NewSpanID(binary.BigEndian.Uint64([]byte{0xAF, 0xAE, 0xAD, 0xAC, 0xAB, 0xAA, 0xA9, 0xA8})),
+		OperationName: "operationA",
+		StartTime:     testSpanStartTime,
+		Duration:      testSpanEndTime.Sub(testSpanStartTime),
+		Logs: []model.Log{
+			{
+				Timestamp: testSpanEventTime,
+				Fields: []model.KeyValue{
+					{
+						Key:   tagMessage,
+						VType: model.ValueType_STRING,
+						VStr:  "event-with-attr",
+					},
+					{
+						Key:   "span-event-attr",
+						VType: model.ValueType_STRING,
+						VStr:  "span-event-attr-val",
+					},
+				},
+			},
+			{
+				Timestamp: testSpanEventTime,
+				Fields: []model.KeyValue{
+					{
+						Key:    "attr-int",
+						VType:  model.ValueType_INT64,
+						VInt64: 123,
+					},
+				},
+			},
+		},
+		Tags: []model.KeyValue{
+			{
+				Key:   tagSpanKind,
+				VType: model.ValueType_STRING,
+				VStr:  string(openTracingSpanKindClient),
+			},
+			{
+				Key:    tagStatusCode,
+				VType:  model.ValueType_INT64,
+				VInt64: int64(otlptrace.Status_STATUS_CODE_CANCELLED),
+			},
+			{
+				Key:   tagError,
+				VBool: true,
+				VType: model.ValueType_BOOL,
+			},
+			{
+				Key:   tagStatusMsg,
+				VType: model.ValueType_STRING,
+				VStr:  "status-cancelled",
+			},
+		},
+	}
+}
+
+func generateProtoChildSpan() *model.Span {
+	traceID := model.NewTraceID(
+		binary.BigEndian.Uint64([]byte{0xF1, 0xF2, 0xF3, 0xF4, 0xF5, 0xF6, 0xF7, 0xF8}),
+		binary.BigEndian.Uint64([]byte{0xF9, 0xFA, 0xFB, 0xFC, 0xFD, 0xFE, 0xFF, 0x80}),
+	)
+	return &model.Span{
+		TraceID:       traceID,
+		SpanID:        model.NewSpanID(binary.BigEndian.Uint64([]byte{0x1F, 0x1E, 0x1D, 0x1C, 0x1B, 0x1A, 0x19, 0x18})),
+		OperationName: "operationB",
+		StartTime:     testSpanStartTime,
+		Duration:      testSpanEndTime.Sub(testSpanStartTime),
+		Tags: []model.KeyValue{
+			{
+				Key:    tagHTTPStatusCode,
+				VType:  model.ValueType_INT64,
+				VInt64: 404,
+			},
+			{
+				Key:   tagSpanKind,
+				VType: model.ValueType_STRING,
+				VStr:  string(openTracingSpanKindServer),
+			},
+		},
+		References: []model.SpanRef{
+			{
+				TraceID: traceID,
+				SpanID:  model.NewSpanID(binary.BigEndian.Uint64([]byte{0xAF, 0xAE, 0xAD, 0xAC, 0xAB, 0xAA, 0xA9, 0xA8})),
+				RefType: model.SpanRefType_CHILD_OF,
+			},
+		},
+	}
+}
+
+func generateProtoFollowerSpan() *model.Span {
+	traceID := model.NewTraceID(
+		binary.BigEndian.Uint64([]byte{0xF1, 0xF2, 0xF3, 0xF4, 0xF5, 0xF6, 0xF7, 0xF8}),
+		binary.BigEndian.Uint64([]byte{0xF9, 0xFA, 0xFB, 0xFC, 0xFD, 0xFE, 0xFF, 0x80}),
+	)
+	return &model.Span{
+		TraceID:       traceID,
+		SpanID:        model.NewSpanID(binary.BigEndian.Uint64([]byte{0x1F, 0x1E, 0x1D, 0x1C, 0x1B, 0x1A, 0x19, 0x18})),
+		OperationName: "operationC",
+		StartTime:     testSpanEndTime,
+		Duration:      time.Millisecond,
+		Tags: []model.KeyValue{
+			{
+				Key:   tagSpanKind,
+				VType: model.ValueType_STRING,
+				VStr:  string(openTracingSpanKindConsumer),
+			},
+			{
+				Key:    tagStatusCode,
+				VType:  model.ValueType_INT64,
+				VInt64: int64(otlptrace.Status_STATUS_CODE_OK),
+			},
+			{
+				Key:   tagStatusMsg,
+				VType: model.ValueType_STRING,
+				VStr:  "status-ok",
+			},
+		},
+		References: []model.SpanRef{
+			{
+				TraceID: traceID,
+				SpanID:  model.NewSpanID(binary.BigEndian.Uint64([]byte{0xAF, 0xAE, 0xAD, 0xAC, 0xAB, 0xAA, 0xA9, 0xA8})),
+				RefType: model.SpanRefType_FOLLOWS_FROM,
+			},
+		},
+	}
+}
+
+func generateProtoSpanWithLibraryInfo(libraryName string) *model.Span {
+	span := generateProtoSpan()
+	span.Tags = append([]model.KeyValue{
+		{
+
+			Key:   tagInstrumentationName,
+			VType: model.ValueType_STRING,
+			VStr:  libraryName,
+		},
+		{
+			Key:   tagInstrumentationVersion,
+			VType: model.ValueType_STRING,
+			VStr:  "0.42.0",
+		},
+	}, span.Tags...)
+
+	return span
+}
+
+func generateProtoSpanWithTraceState() *model.Span {
+	span := generateProtoSpan()
+	span.Tags = []model.KeyValue{
+		{
+			Key:   tagW3CTraceState,
+			VType: model.ValueType_STRING,
+			VStr:  "lasterror=f39cd56cc44274fd5abd07ef1164246d10ce2955",
+		},
+		{
+			Key:   tagSpanKind,
+			VType: model.ValueType_STRING,
+			VStr:  string(openTracingSpanKindClient),
+		},
+	}
+	return span
+}
+
+func generateOtlpResource() *otlpresource.Resource {
+	return &otlpresource.Resource{
+		Attributes: []*otlpcommon.KeyValue{
+			{
+				Key:   attributeServiceName,
+				Value: &otlpcommon.AnyValue{Value: &otlpcommon.AnyValue_StringValue{StringValue: "service"}},
+			},
+			{
+				Key:   "int-attr",
+				Value: &otlpcommon.AnyValue{Value: &otlpcommon.AnyValue_IntValue{IntValue: 123}},
+			},
+		},
+	}
+}
+
+func generateOtlpSpan() *otlptrace.Span {
+	span := &otlptrace.Span{}
+	span.SpanId = []byte{0xAF, 0xAE, 0xAD, 0xAC, 0xAB, 0xAA, 0xA9, 0xA8}
+	span.TraceId = []byte{0xF1, 0xF2, 0xF3, 0xF4, 0xF5, 0xF6, 0xF7, 0xF8, 0xF9, 0xFA, 0xFB, 0xFC, 0xFD, 0xFE, 0xFF, 0x80}
+	span.Name = "operationA"
+	span.StartTimeUnixNano = uint64(testSpanStartTimestamp)
+	span.EndTimeUnixNano = uint64(testSpanEndTimestamp)
+	span.Kind = otlptrace.Span_SPAN_KIND_CLIENT
+	span.Events = []*otlptrace.Span_Event{
+		{
+			TimeUnixNano: uint64(testSpanEventTimestamp),
+			Name:         "event-with-attr",
+			Attributes: []*otlpcommon.KeyValue{
+				{
+					Key:   "span-event-attr",
+					Value: &otlpcommon.AnyValue{Value: &otlpcommon.AnyValue_StringValue{StringValue: "span-event-attr-val"}},
+				},
+			},
+		},
+		{
+			TimeUnixNano: uint64(testSpanEventTimestamp),
+			Attributes: []*otlpcommon.KeyValue{
+				{
+					Key:   "attr-int",
+					Value: &otlpcommon.AnyValue{Value: &otlpcommon.AnyValue_IntValue{IntValue: 123}},
+				},
+			},
+		},
+	}
+	span.Status = &otlptrace.Status{
+		Code:    otlptrace.Status_STATUS_CODE_CANCELLED,
+		Message: "status-cancelled",
+	}
+	return span
+}
+
+func generateOtlpChildSpan() *otlptrace.Span {
+	span := generateOtlpSpan()
+	originalSpanID := span.SpanId
+	span.Name = "operationB"
+	span.SpanId = []byte{0x1F, 0x1E, 0x1D, 0x1C, 0x1B, 0x1A, 0x19, 0x18}
+	span.ParentSpanId = originalSpanID
+	span.Kind = otlptrace.Span_SPAN_KIND_SERVER
+	span.Status = &otlptrace.Status{
+		Code: otlptrace.Status_STATUS_CODE_NOT_FOUND,
+	}
+	span.Events = nil
+	span.Attributes = []*otlpcommon.KeyValue{
+		{
+			Key:   tagHTTPStatusCode,
+			Value: &otlpcommon.AnyValue{Value: &otlpcommon.AnyValue_IntValue{IntValue: 404}},
+		},
+	}
+
+	return span
+}
+
+func generateOtlpFollowerSpan() *otlptrace.Span {
+	span := generateOtlpSpan()
+	originalSpanID := span.SpanId
+	span.Name = "operationC"
+	span.SpanId = []byte{0x1F, 0x1E, 0x1D, 0x1C, 0x1B, 0x1A, 0x19, 0x18}
+	span.StartTimeUnixNano = span.EndTimeUnixNano
+	span.EndTimeUnixNano = span.EndTimeUnixNano + 1000000
+	span.Kind = otlptrace.Span_SPAN_KIND_CONSUMER
+	span.Events = nil
+	span.Status = &otlptrace.Status{
+		Code:    otlptrace.Status_STATUS_CODE_OK,
+		Message: "status-ok",
+	}
+	span.Links = []*otlptrace.Span_Link{
+		{
+			TraceId: span.TraceId,
+			SpanId:  originalSpanID,
+		},
+	}
+	return span
+}
+
+func generateOtlpSpanWithTraceState() *otlptrace.Span {
+	span := generateOtlpSpan()
+	span.Status = nil
+	span.Attributes = []*otlpcommon.KeyValue{
+		{
+			Key: tagW3CTraceState,
+			Value: &otlpcommon.AnyValue{
+				Value: &otlpcommon.AnyValue_StringValue{StringValue: "lasterror=f39cd56cc44274fd5abd07ef1164246d10ce2955"},
+			},
+		},
+	}
+	return span
+}


### PR DESCRIPTION
Code was inspired from the otel-collector because the code in the collector
cannot be consumed as a library and there are too many dependecies to bring.

Signed-off-by: Bogdan Drutu <bogdandrutu@gmail.com>