### PR TITLE
Add helper function to convert from otlp attributes array/map to json string

### DIFF
--- a/otlp/attr_to_string.go
+++ b/otlp/attr_to_string.go
@@ -1,0 +1,88 @@
+// Copyright 2020 Splunk, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package otlp
+
+import (
+	"encoding/json"
+
+	otlpcommon "github.com/signalfx/sapm-proto/gen/otlp/common/v1"
+)
+
+// keyValueListToJSONString converts an OTLP otlpcommon.KeyValueList to a JSON string.
+func keyValueListToJSONString(attrMap *otlpcommon.KeyValueList) string {
+	rawMap := attributeMapToMap(attrMap)
+	js, _ := json.Marshal(rawMap)
+	return string(js)
+}
+
+// arrayValueToJSONString converts an OTLP otlpcommon.ArrayValue to a JSON string.
+func arrayValueToJSONString(attrArray *otlpcommon.ArrayValue) string {
+	rawSlice := attributeArrayToArray(attrArray)
+	js, _ := json.Marshal(rawSlice)
+	return string(js)
+}
+
+func attributeMapToMap(attrMap *otlpcommon.KeyValueList) map[string]interface{} {
+	if attrMap == nil {
+		return nil
+	}
+	rawMap := make(map[string]interface{}, len(attrMap.GetValues()))
+	for _, attr := range attrMap.GetValues() {
+		switch v := attr.GetValue().GetValue().(type) {
+		case *otlpcommon.AnyValue_StringValue:
+			rawMap[attr.Key] = v.StringValue
+		case *otlpcommon.AnyValue_BoolValue:
+			rawMap[attr.Key] = v.BoolValue
+		case *otlpcommon.AnyValue_IntValue:
+			rawMap[attr.Key] = v.IntValue
+		case *otlpcommon.AnyValue_DoubleValue:
+			rawMap[attr.Key] = v.DoubleValue
+		case *otlpcommon.AnyValue_KvlistValue:
+			rawMap[attr.Key] = attributeMapToMap(v.KvlistValue)
+		case *otlpcommon.AnyValue_ArrayValue:
+			rawMap[attr.Key] = attributeArrayToArray(v.ArrayValue)
+		default:
+			rawMap[attr.Key] = nil
+		}
+	}
+	return rawMap
+}
+
+func attributeArrayToArray(attrArray *otlpcommon.ArrayValue) []interface{} {
+	if attrArray == nil {
+		return nil
+	}
+	rawSlice := make([]interface{}, 0, len(attrArray.Values))
+	for _, attr := range attrArray.GetValues() {
+		switch v := attr.GetValue().(type) {
+		case *otlpcommon.AnyValue_StringValue:
+			rawSlice = append(rawSlice, v.StringValue)
+		case *otlpcommon.AnyValue_BoolValue:
+			rawSlice = append(rawSlice, v.BoolValue)
+		case *otlpcommon.AnyValue_IntValue:
+			rawSlice = append(rawSlice, v.IntValue)
+		case *otlpcommon.AnyValue_DoubleValue:
+			rawSlice = append(rawSlice, v.DoubleValue)
+		case *otlpcommon.AnyValue_KvlistValue:
+			rawSlice = append(rawSlice, "<Invalid array value>")
+		case *otlpcommon.AnyValue_ArrayValue:
+			rawSlice = append(rawSlice, "<Invalid array value>")
+		default:
+			rawSlice = append(rawSlice, nil)
+		}
+	}
+
+	return rawSlice
+}

--- a/otlp/attr_to_string_test.go
+++ b/otlp/attr_to_string_test.go
@@ -1,0 +1,201 @@
+// Copyright 2020 Splunk, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package otlp
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	otlpcommon "github.com/signalfx/sapm-proto/gen/otlp/common/v1"
+)
+
+func TestKeyValueListToJSONString(t *testing.T) {
+	valueMap := &otlpcommon.KeyValueList{
+		Values: []*otlpcommon.KeyValue{
+			{
+				Key: "strKey",
+				Value: &otlpcommon.AnyValue{
+					Value: &otlpcommon.AnyValue_StringValue{
+						StringValue: "strVal",
+					},
+				},
+			},
+			{
+				Key: "intKey",
+				Value: &otlpcommon.AnyValue{
+					Value: &otlpcommon.AnyValue_IntValue{
+						IntValue: 7,
+					},
+				},
+			},
+			{
+				Key: "floatKey",
+				Value: &otlpcommon.AnyValue{
+					Value: &otlpcommon.AnyValue_DoubleValue{
+						DoubleValue: 18.6,
+					},
+				},
+			},
+			{
+				Key: "boolKey",
+				Value: &otlpcommon.AnyValue{
+					Value: &otlpcommon.AnyValue_BoolValue{
+						BoolValue: false,
+					},
+				},
+			},
+			{
+				Key: "nullKey",
+			},
+			{
+				Key: "mapKey",
+				Value: &otlpcommon.AnyValue{
+					Value: &otlpcommon.AnyValue_KvlistValue{
+						KvlistValue: &otlpcommon.KeyValueList{
+							Values: []*otlpcommon.KeyValue{
+								{
+									Key: "keyOne",
+									Value: &otlpcommon.AnyValue{
+										Value: &otlpcommon.AnyValue_StringValue{
+											StringValue: "valOne",
+										},
+									},
+								},
+								{
+									Key: "keyTwo",
+									Value: &otlpcommon.AnyValue{
+										Value: &otlpcommon.AnyValue_StringValue{
+											StringValue: "valTwo",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			{
+				Key: "arrKey",
+				Value: &otlpcommon.AnyValue{
+					Value: &otlpcommon.AnyValue_ArrayValue{
+						ArrayValue: &otlpcommon.ArrayValue{
+							Values: []*otlpcommon.AnyValue{
+								{
+									Value: &otlpcommon.AnyValue_StringValue{
+										StringValue: "strOne",
+									},
+								},
+								{
+									Value: &otlpcommon.AnyValue_StringValue{
+										StringValue: "strTwo",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	expected := `{"arrKey":["strOne","strTwo"],"boolKey":false,"floatKey":18.6,"intKey":7,"mapKey":{"keyOne":"valOne","keyTwo":"valTwo"},"nullKey":null,"strKey":"strVal"}`
+
+	strVal := keyValueListToJSONString(valueMap)
+	assert.EqualValues(t, expected, strVal)
+}
+
+func TestKeyValueListToJSONString_Nil(t *testing.T) {
+	strVal := keyValueListToJSONString(nil)
+	assert.EqualValues(t, "null", strVal)
+}
+
+func TestArrayValueToJSONString(t *testing.T) {
+	valueMap := &otlpcommon.ArrayValue{
+		Values: []*otlpcommon.AnyValue{
+			{
+				Value: &otlpcommon.AnyValue_StringValue{
+					StringValue: "strVal",
+				},
+			},
+			{
+				Value: &otlpcommon.AnyValue_IntValue{
+					IntValue: 7,
+				},
+			},
+			{
+				Value: &otlpcommon.AnyValue_DoubleValue{
+					DoubleValue: 18.6,
+				},
+			},
+			{
+				Value: &otlpcommon.AnyValue_BoolValue{
+					BoolValue: false,
+				},
+			},
+			{},
+			{
+				Value: &otlpcommon.AnyValue_KvlistValue{
+					KvlistValue: &otlpcommon.KeyValueList{
+						Values: []*otlpcommon.KeyValue{
+							{
+								Key: "keyOne",
+								Value: &otlpcommon.AnyValue{
+									Value: &otlpcommon.AnyValue_StringValue{
+										StringValue: "valOne",
+									},
+								},
+							},
+							{
+								Key: "keyTwo",
+								Value: &otlpcommon.AnyValue{
+									Value: &otlpcommon.AnyValue_StringValue{
+										StringValue: "valTwo",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			{
+				Value: &otlpcommon.AnyValue_ArrayValue{
+					ArrayValue: &otlpcommon.ArrayValue{
+						Values: []*otlpcommon.AnyValue{
+							{
+								Value: &otlpcommon.AnyValue_StringValue{
+									StringValue: "strOne",
+								},
+							},
+							{
+								Value: &otlpcommon.AnyValue_StringValue{
+									StringValue: "strTwo",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	expected := `["strVal",7,18.6,false,null,"\u003cInvalid array value\u003e","\u003cInvalid array value\u003e"]`
+
+	strVal := arrayValueToJSONString(valueMap)
+	assert.EqualValues(t, expected, strVal)
+}
+
+func TestArrayValueToJSONString_Nil(t *testing.T) {
+	strVal := arrayValueToJSONString(nil)
+	assert.EqualValues(t, "null", strVal)
+}


### PR DESCRIPTION
Split from https://github.com/signalfx/sapm-proto/pull/25

Signed-off-by: Bogdan Drutu <bogdandrutu@gmail.com>