### PR TITLE
Add support to translate from OTLP to SAPM

### DIFF
--- a/otlp/attr_to_string.go
+++ b/otlp/attr_to_string.go
@@ -1,4 +1,5 @@
 // Copyright 2020 Splunk, Inc.
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/otlp/attr_to_string_test.go
+++ b/otlp/attr_to_string_test.go
@@ -1,4 +1,5 @@
 // Copyright 2020 Splunk, Inc.
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/otlp/constants.go
+++ b/otlp/constants.go
@@ -1,0 +1,49 @@
+// Copyright 2020 Splunk, Inc.
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package otlp
+
+// Some of the keys used to represent OTLP constructs as tags or annotations in Jaeger.
+const (
+	attributeServiceName = "service.name"
+
+	tagMessage        = "message"
+	tagSpanKind       = "span.kind"
+	tagStatusCode     = "status.code"
+	tagStatusMsg      = "status.message"
+	tagError          = "error"
+	tagHTTPStatusCode = "http.status_code"
+
+	tagW3CTraceState          = "w3c.tracestate"
+	tagInstrumentationName    = "otlp.instrumentation_library.name"
+	tagInstrumentationVersion = "otlp.instrumentation_library.version"
+)
+
+// Constants used for signifying batch-level attribute values where not supplied by OTLP data but required
+// by other protocols.
+const (
+	resourceNotSet        = "OTLPResourceNotSet"
+	resourceNoServiceName = "OTLPResourceNoServiceName"
+)
+
+// OpenTracingSpanKind are possible values for tagSpanKind and match the OpenTracing
+// conventions: https://github.com/opentracing/specification/blob/master/semantic_conventions.md
+const (
+	openTracingSpanKindClient   = "client"
+	openTracingSpanKindServer   = "server"
+	openTracingSpanKindConsumer = "consumer"
+	openTracingSpanKindProducer = "producer"
+	openTracingSpanKindInternal = "internal"
+)

--- a/otlp/translator.go
+++ b/otlp/translator.go
@@ -1,0 +1,462 @@
+// Copyright 2020 Splunk, Inc.
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package otlp
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/jaegertracing/jaeger/model"
+
+	splunksapm "github.com/signalfx/sapm-proto/gen"
+	otlpcoltrace "github.com/signalfx/sapm-proto/gen/otlp/collector/trace/v1"
+	otlpcommon "github.com/signalfx/sapm-proto/gen/otlp/common/v1"
+	otlpresource "github.com/signalfx/sapm-proto/gen/otlp/resource/v1"
+	otlptrace "github.com/signalfx/sapm-proto/gen/otlp/trace/v1"
+)
+
+// otlpToSAPM translates otlp trace proto into the SAPM Proto.
+func otlpToSAPM(td otlpcoltrace.ExportTraceServiceRequest) (*splunksapm.PostSpansRequest, error) {
+	sapm := &splunksapm.PostSpansRequest{}
+	if len(td.ResourceSpans) == 0 {
+		return sapm, nil
+	}
+
+	sapm.Batches = make([]*model.Batch, 0, len(td.ResourceSpans))
+
+	for _, rs := range td.ResourceSpans {
+		batch, err := resourceSpansToJaegerProto(rs)
+		if err != nil {
+			return nil, err
+		}
+		// Ignore nil batches. Even if no error (spans may not be present).
+		if batch != nil {
+			sapm.Batches = append(sapm.Batches, batch)
+		}
+	}
+
+	return sapm, nil
+}
+
+func resourceSpansToJaegerProto(rs *otlptrace.ResourceSpans) (*model.Batch, error) {
+	// If no spans do not propagate just the Process.
+	if rs == nil || len(rs.InstrumentationLibrarySpans) == 0 {
+		return nil, nil
+	}
+
+	// Approximate the number of the spans.
+	jSpans := make([]*model.Span, 0, spanCount(rs.InstrumentationLibrarySpans))
+	for _, ils := range rs.InstrumentationLibrarySpans {
+		if ils == nil {
+			continue // ignore nil InstrumentationLibrarySpans
+		}
+
+		spans := ils.Spans
+		for _, span := range spans {
+			if span == nil {
+				continue // ignore nil Span
+			}
+
+			jSpan, err := spanToJaegerProto(span, ils.InstrumentationLibrary)
+			if err != nil {
+				return nil, err
+			}
+
+			jSpans = append(jSpans, jSpan)
+		}
+	}
+
+	// If failed to convert all the spans, no need to return only the process.
+	if len(jSpans) == 0 {
+		return nil, nil
+	}
+
+	return &model.Batch{
+		Process: resourceToJaegerProtoProcess(rs.Resource),
+		Spans:   jSpans,
+	}, nil
+}
+
+func spanCount(ilss []*otlptrace.InstrumentationLibrarySpans) int {
+	sCount := 0
+	for _, ils := range ilss {
+		if ils == nil {
+			continue
+		}
+		sCount += len(ils.Spans)
+	}
+	return sCount
+}
+
+func resourceToJaegerProtoProcess(resource *otlpresource.Resource) *model.Process {
+	process := model.Process{}
+	if resource == nil {
+		process.ServiceName = resourceNotSet
+		return &process
+	}
+
+	var serviceName string
+	process.Tags, serviceName = appendTagsFromResourceAttributes(resource.Attributes)
+	process.ServiceName = serviceName
+	return &process
+
+}
+
+func appendTagsFromResourceAttributes(attrs []*otlpcommon.KeyValue) ([]model.KeyValue, string) {
+	serviceName := resourceNoServiceName
+	if len(attrs) == 0 {
+		return nil, serviceName
+	}
+
+	tags := make([]model.KeyValue, 0, len(attrs))
+	for _, kv := range attrs {
+		if kv.GetKey() == attributeServiceName {
+			serviceName = kv.GetValue().GetStringValue()
+			continue
+		}
+		tags = append(tags, attributeToJaegerProtoTag(kv.GetKey(), kv.GetValue()))
+	}
+	return tags, serviceName
+}
+
+func appendTagsFromAttributes(dest []model.KeyValue, attrs []*otlpcommon.KeyValue) []model.KeyValue {
+	if len(attrs) == 0 {
+		return dest
+	}
+	for _, kv := range attrs {
+		dest = append(dest, attributeToJaegerProtoTag(kv.Key, kv.Value))
+	}
+	return dest
+}
+
+func attributeToJaegerProtoTag(key string, attr *otlpcommon.AnyValue) model.KeyValue {
+	tag := model.KeyValue{Key: key}
+	switch v := attr.GetValue().(type) {
+	case *otlpcommon.AnyValue_StringValue:
+		// Jaeger-to-Internal maps binary tags to string attributes and encodes them as
+		// base64 strings. Blindingly attempting to decode base64 seems too much.
+		tag.VType = model.ValueType_STRING
+		tag.VStr = v.StringValue
+	case *otlpcommon.AnyValue_BoolValue:
+		tag.VType = model.ValueType_BOOL
+		tag.VBool = v.BoolValue
+	case *otlpcommon.AnyValue_IntValue:
+		tag.VType = model.ValueType_INT64
+		tag.VInt64 = v.IntValue
+	case *otlpcommon.AnyValue_DoubleValue:
+		tag.VType = model.ValueType_FLOAT64
+		tag.VFloat64 = v.DoubleValue
+	case *otlpcommon.AnyValue_KvlistValue:
+		tag.VType = model.ValueType_STRING
+		tag.VStr = keyValueListToJSONString(v.KvlistValue)
+	case *otlpcommon.AnyValue_ArrayValue:
+		tag.VType = model.ValueType_STRING
+		tag.VStr = arrayValueToJSONString(v.ArrayValue)
+	}
+	return tag
+}
+
+func spanToJaegerProto(span *otlptrace.Span, instLibrary *otlpcommon.InstrumentationLibrary) (*model.Span, error) {
+	traceID, err := model.TraceIDFromBytes(span.TraceId)
+	if err != nil {
+		return nil, fmt.Errorf("incorrect trace ID: %w", err)
+	}
+
+	spanID, err := model.SpanIDFromBytes(span.SpanId)
+	if err != nil {
+		return nil, fmt.Errorf("incorrect span ID: %w", err)
+	}
+
+	jReferences, err := makeJaegerProtoReferences(span.Links, span.ParentSpanId, traceID)
+	if err != nil {
+		return nil, fmt.Errorf("error converting span links to Jaeger references: %w", err)
+	}
+
+	startTime := unixNanoToTime(span.StartTimeUnixNano)
+
+	return &model.Span{
+		TraceID:       traceID,
+		SpanID:        spanID,
+		OperationName: span.Name,
+		References:    jReferences,
+		StartTime:     startTime,
+		Duration:      unixNanoToTime(span.EndTimeUnixNano).Sub(startTime),
+		Tags:          getJaegerProtoSpanTags(span, instLibrary),
+		Logs:          spanEventsToJaegerProtoLogs(span.Events),
+	}, nil
+}
+
+func getJaegerProtoSpanTags(span *otlptrace.Span, instLibrary *otlpcommon.InstrumentationLibrary) []model.KeyValue {
+	var spanKindTag, statusCodeTag, errorTag, statusMsgTag model.KeyValue
+	var spanKindTagFound, statusCodeTagFound, errorTagFound, statusMsgTagFound bool
+
+	libraryTags, libraryTagsFound := getTagsFromInstrumentationLibrary(instLibrary)
+
+	tagsCount := len(span.Attributes) + len(libraryTags)
+
+	spanKindTag, spanKindTagFound = getTagFromSpanKind(span.Kind)
+	if spanKindTagFound {
+		tagsCount++
+	}
+	status := span.Status
+	if status != nil {
+		statusCodeTag, statusCodeTagFound = getTagFromStatusCode(status.Code)
+		if statusCodeTagFound {
+			tagsCount++
+		}
+
+		errorTag, errorTagFound = getErrorTagFromStatusCode(status.Code)
+		if errorTagFound {
+			tagsCount++
+		}
+
+		statusMsgTag, statusMsgTagFound = getTagFromStatusMsg(status.Message)
+		if statusMsgTagFound {
+			tagsCount++
+		}
+	}
+
+	traceStateTags, traceStateTagsFound := getTagFromTraceState(span.TraceState)
+	if traceStateTagsFound {
+		tagsCount++
+	}
+
+	if tagsCount == 0 {
+		return nil
+	}
+
+	tags := make([]model.KeyValue, 0, tagsCount)
+	if libraryTagsFound {
+		tags = append(tags, libraryTags...)
+	}
+	tags = appendTagsFromAttributes(tags, span.Attributes)
+	if spanKindTagFound {
+		tags = append(tags, spanKindTag)
+	}
+	if statusCodeTagFound {
+		tags = append(tags, statusCodeTag)
+	}
+	if errorTagFound {
+		tags = append(tags, errorTag)
+	}
+	if statusMsgTagFound {
+		tags = append(tags, statusMsgTag)
+	}
+	if traceStateTagsFound {
+		tags = append(tags, traceStateTags)
+	}
+	return tags
+}
+
+// makeJaegerProtoReferences constructs jaeger span references based on parent span ID and span links
+func makeJaegerProtoReferences(links []*otlptrace.Span_Link, parentSpanID []byte, traceID model.TraceID) ([]model.SpanRef, error) {
+	parentSpanIDSet := len(parentSpanID) != 0
+	if !parentSpanIDSet && len(links) == 0 {
+		return nil, nil
+	}
+
+	refsCount := len(links)
+	if parentSpanIDSet {
+		refsCount++
+	}
+
+	refs := make([]model.SpanRef, 0, refsCount)
+
+	// Put parent span ID at the first place because usually backends look for it
+	// as the first CHILD_OF item in the model.SpanRef slice.
+	if parentSpanIDSet {
+		jParentSpanID, err := model.SpanIDFromBytes(parentSpanID)
+		if err != nil {
+			return nil, fmt.Errorf("incorrect parent span ID: %w", err)
+		}
+
+		refs = append(refs, model.SpanRef{
+			TraceID: traceID,
+			SpanID:  jParentSpanID,
+			RefType: model.SpanRefType_CHILD_OF,
+		})
+	}
+
+	for _, link := range links {
+		if link == nil {
+			continue
+		}
+
+		traceID, err := model.TraceIDFromBytes(link.TraceId)
+		if err != nil {
+			return nil, fmt.Errorf("incorrect linked trace ID: %w", err)
+		}
+
+		spanID, err := model.SpanIDFromBytes(link.SpanId)
+		if err != nil {
+			return nil, fmt.Errorf("incorrect linked span ID: %w", err)
+		}
+
+		refs = append(refs, model.SpanRef{
+			TraceID: traceID,
+			SpanID:  spanID,
+
+			// Since Jaeger RefType is not captured in internal data,
+			// use SpanRefType_FOLLOWS_FROM by default.
+			// SpanRefType_CHILD_OF supposed to be set only from parentSpanID.
+			RefType: model.SpanRefType_FOLLOWS_FROM,
+		})
+	}
+
+	if len(refs) == 0 {
+		return nil, nil
+	}
+
+	return refs, nil
+}
+
+func spanEventsToJaegerProtoLogs(events []*otlptrace.Span_Event) []model.Log {
+	if len(events) == 0 {
+		return nil
+	}
+
+	logs := make([]model.Log, 0, len(events))
+	for _, event := range events {
+		if event == nil {
+			continue
+		}
+
+		hasName := event.Name != ""
+		fieldsCount := len(event.Attributes)
+		if hasName {
+			fieldsCount++
+		}
+
+		fields := make([]model.KeyValue, 0, fieldsCount)
+		if hasName {
+			fields = append(fields, model.KeyValue{
+				Key:   tagMessage,
+				VType: model.ValueType_STRING,
+				VStr:  event.Name,
+			})
+		}
+		fields = appendTagsFromAttributes(fields, event.Attributes)
+		logs = append(logs, model.Log{
+			Timestamp: unixNanoToTime(event.TimeUnixNano),
+			Fields:    fields,
+		})
+	}
+
+	// If no logs, then return a nil slice to not reference memory unnecessary.
+	if len(logs) == 0 {
+		logs = nil
+	}
+	return logs
+}
+
+func getTagFromSpanKind(spanKind otlptrace.Span_SpanKind) (model.KeyValue, bool) {
+	var tagStr string
+	switch spanKind {
+	case otlptrace.Span_SPAN_KIND_CLIENT:
+		tagStr = openTracingSpanKindClient
+	case otlptrace.Span_SPAN_KIND_SERVER:
+		tagStr = openTracingSpanKindServer
+	case otlptrace.Span_SPAN_KIND_PRODUCER:
+		tagStr = openTracingSpanKindProducer
+	case otlptrace.Span_SPAN_KIND_CONSUMER:
+		tagStr = openTracingSpanKindConsumer
+	case otlptrace.Span_SPAN_KIND_INTERNAL:
+		tagStr = openTracingSpanKindInternal
+	default:
+		return model.KeyValue{}, false
+	}
+
+	return model.KeyValue{
+		Key:   tagSpanKind,
+		VType: model.ValueType_STRING,
+		VStr:  tagStr,
+	}, true
+}
+
+func getTagFromStatusCode(statusCode otlptrace.Status_StatusCode) (model.KeyValue, bool) {
+	return model.KeyValue{
+		Key:    tagStatusCode,
+		VInt64: int64(statusCode),
+		VType:  model.ValueType_INT64,
+	}, true
+}
+
+func getErrorTagFromStatusCode(statusCode otlptrace.Status_StatusCode) (model.KeyValue, bool) {
+	if statusCode == otlptrace.Status_STATUS_CODE_OK {
+		return model.KeyValue{}, false
+	}
+	return model.KeyValue{
+		Key:   tagError,
+		VBool: true,
+		VType: model.ValueType_BOOL,
+	}, true
+}
+
+func getTagFromStatusMsg(statusMsg string) (model.KeyValue, bool) {
+	if statusMsg == "" {
+		return model.KeyValue{}, false
+	}
+	return model.KeyValue{
+		Key:   tagStatusMsg,
+		VStr:  statusMsg,
+		VType: model.ValueType_STRING,
+	}, true
+}
+
+func getTagFromTraceState(traceState string) (model.KeyValue, bool) {
+	if traceState != "" {
+		// TODO Bring this inline with solution for jaegertracing/jaeger-client-java #702 once available
+		return model.KeyValue{
+			Key:   tagW3CTraceState,
+			VStr:  traceState,
+			VType: model.ValueType_STRING,
+		}, true
+	}
+	return model.KeyValue{}, false
+}
+
+func getTagsFromInstrumentationLibrary(il *otlpcommon.InstrumentationLibrary) ([]model.KeyValue, bool) {
+	var keyValues []model.KeyValue
+	if il == nil {
+		return keyValues, false
+	}
+	if il.Name != "" {
+		kv := model.KeyValue{
+			Key:   tagInstrumentationName,
+			VStr:  il.Name,
+			VType: model.ValueType_STRING,
+		}
+		keyValues = append(keyValues, kv)
+	}
+	if il.Version != "" {
+		kv := model.KeyValue{
+			Key:   tagInstrumentationVersion,
+			VStr:  il.Version,
+			VType: model.ValueType_STRING,
+		}
+		keyValues = append(keyValues, kv)
+	}
+
+	return keyValues, true
+}
+
+func unixNanoToTime(t uint64) time.Time {
+	// 0 is a special case and want to make sure we return a time that IsZero() returns true.
+	if t == 0 {
+		return time.Time{}
+	}
+	return time.Unix(0, int64(t)).UTC()
+}

--- a/otlp/translator_test.go
+++ b/otlp/translator_test.go
@@ -1,0 +1,1021 @@
+// Copyright 2020 Splunk, Inc.
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package otlp
+
+import (
+	"encoding/binary"
+	"testing"
+	"time"
+
+	"github.com/jaegertracing/jaeger/model"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	splunksapm "github.com/signalfx/sapm-proto/gen"
+	otlpcoltrace "github.com/signalfx/sapm-proto/gen/otlp/collector/trace/v1"
+	otlpcommon "github.com/signalfx/sapm-proto/gen/otlp/common/v1"
+	otlpresource "github.com/signalfx/sapm-proto/gen/otlp/resource/v1"
+	otlptrace "github.com/signalfx/sapm-proto/gen/otlp/trace/v1"
+)
+
+// Use timespamp with microsecond granularity to work well with jaeger thrift translation
+var (
+	testSpanStartTime      = time.Date(2020, 2, 11, 20, 26, 12, 321000, time.UTC)
+	testSpanStartTimestamp = testSpanStartTime.UnixNano()
+	testSpanEventTime      = time.Date(2020, 2, 11, 20, 26, 13, 123000, time.UTC)
+	testSpanEventTimestamp = testSpanEventTime.UnixNano()
+	testSpanEndTime        = time.Date(2020, 2, 11, 20, 26, 13, 789000, time.UTC)
+	testSpanEndTimestamp   = testSpanEndTime.UnixNano()
+)
+
+func TestGetTagFromStatusCode(t *testing.T) {
+	tests := []struct {
+		name string
+		code otlptrace.Status_StatusCode
+		tag  model.KeyValue
+	}{
+		{
+			name: "ok",
+			code: otlptrace.Status_STATUS_CODE_OK,
+			tag: model.KeyValue{
+				Key:    tagStatusCode,
+				VInt64: int64(otlptrace.Status_STATUS_CODE_OK),
+				VType:  model.ValueType_INT64,
+			},
+		},
+
+		{
+			name: "unknown",
+			code: otlptrace.Status_STATUS_CODE_UNKNOWN_ERROR,
+			tag: model.KeyValue{
+				Key:    tagStatusCode,
+				VInt64: int64(otlptrace.Status_STATUS_CODE_UNKNOWN_ERROR),
+				VType:  model.ValueType_INT64,
+			},
+		},
+
+		{
+			name: "not-found",
+			code: otlptrace.Status_STATUS_CODE_NOT_FOUND,
+			tag: model.KeyValue{
+				Key:    tagStatusCode,
+				VInt64: int64(otlptrace.Status_STATUS_CODE_NOT_FOUND),
+				VType:  model.ValueType_INT64,
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got, ok := getTagFromStatusCode(test.code)
+			assert.True(t, ok)
+			assert.EqualValues(t, test.tag, got)
+		})
+	}
+}
+
+func TestGetErrorTagFromStatusCode(t *testing.T) {
+	errTag := model.KeyValue{
+		Key:   tagError,
+		VBool: true,
+		VType: model.ValueType_BOOL,
+	}
+
+	_, ok := getErrorTagFromStatusCode(otlptrace.Status_STATUS_CODE_OK)
+	assert.False(t, ok)
+
+	got, ok := getErrorTagFromStatusCode(otlptrace.Status_STATUS_CODE_UNKNOWN_ERROR)
+	assert.True(t, ok)
+	assert.EqualValues(t, errTag, got)
+
+	got, ok = getErrorTagFromStatusCode(otlptrace.Status_STATUS_CODE_NOT_FOUND)
+	assert.True(t, ok)
+	assert.EqualValues(t, errTag, got)
+}
+
+func TestGetTagFromStatusMsg(t *testing.T) {
+	got, ok := getTagFromStatusMsg("")
+	assert.False(t, ok)
+
+	got, ok = getTagFromStatusMsg("test-error")
+	assert.True(t, ok)
+	assert.EqualValues(t, model.KeyValue{
+		Key:   tagStatusMsg,
+		VStr:  "test-error",
+		VType: model.ValueType_STRING,
+	}, got)
+}
+
+func TestUnixNanoToTime(t *testing.T) {
+	tt := unixNanoToTime(0)
+	assert.True(t, tt.IsZero())
+}
+
+func TestGetTagFromSpanKind(t *testing.T) {
+	tests := []struct {
+		name string
+		kind otlptrace.Span_SpanKind
+		tag  model.KeyValue
+		ok   bool
+	}{
+		{
+			name: "unspecified",
+			kind: otlptrace.Span_SPAN_KIND_UNSPECIFIED,
+			tag:  model.KeyValue{},
+			ok:   false,
+		},
+
+		{
+			name: "client",
+			kind: otlptrace.Span_SPAN_KIND_CLIENT,
+			tag: model.KeyValue{
+				Key:   tagSpanKind,
+				VType: model.ValueType_STRING,
+				VStr:  openTracingSpanKindClient,
+			},
+			ok: true,
+		},
+
+		{
+			name: "server",
+			kind: otlptrace.Span_SPAN_KIND_SERVER,
+			tag: model.KeyValue{
+				Key:   tagSpanKind,
+				VType: model.ValueType_STRING,
+				VStr:  openTracingSpanKindServer,
+			},
+			ok: true,
+		},
+
+		{
+			name: "producer",
+			kind: otlptrace.Span_SPAN_KIND_PRODUCER,
+			tag: model.KeyValue{
+				Key:   tagSpanKind,
+				VType: model.ValueType_STRING,
+				VStr:  openTracingSpanKindProducer,
+			},
+			ok: true,
+		},
+
+		{
+			name: "consumer",
+			kind: otlptrace.Span_SPAN_KIND_CONSUMER,
+			tag: model.KeyValue{
+				Key:   tagSpanKind,
+				VType: model.ValueType_STRING,
+				VStr:  openTracingSpanKindConsumer,
+			},
+			ok: true,
+		},
+
+		{
+			name: "internal",
+			kind: otlptrace.Span_SPAN_KIND_INTERNAL,
+			tag: model.KeyValue{
+				Key:   tagSpanKind,
+				VType: model.ValueType_STRING,
+				VStr:  openTracingSpanKindInternal,
+			},
+			ok: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got, ok := getTagFromSpanKind(test.kind)
+			assert.Equal(t, test.ok, ok)
+			assert.EqualValues(t, test.tag, got)
+		})
+	}
+}
+
+func TestAttributesToJaegerProtoTags(t *testing.T) {
+	attributes := []*otlpcommon.KeyValue{
+		{
+			Key: "bool-val",
+			Value: &otlpcommon.AnyValue{
+				Value: &otlpcommon.AnyValue_BoolValue{
+					BoolValue: true,
+				},
+			},
+		},
+		{
+			Key: "int-val",
+			Value: &otlpcommon.AnyValue{
+				Value: &otlpcommon.AnyValue_IntValue{
+					IntValue: 123,
+				},
+			},
+		},
+		{
+			Key: "string-val",
+			Value: &otlpcommon.AnyValue{
+				Value: &otlpcommon.AnyValue_StringValue{
+					StringValue: "abc",
+				},
+			},
+		},
+		{
+			Key: "double-val",
+			Value: &otlpcommon.AnyValue{
+				Value: &otlpcommon.AnyValue_DoubleValue{
+					DoubleValue: 1.23,
+				},
+			},
+		},
+		{
+			Key: "map-val",
+			Value: &otlpcommon.AnyValue{
+				Value: &otlpcommon.AnyValue_KvlistValue{
+					KvlistValue: &otlpcommon.KeyValueList{
+						Values: []*otlpcommon.KeyValue{
+							{
+								Key: "key-map-val",
+								Value: &otlpcommon.AnyValue{
+									Value: &otlpcommon.AnyValue_IntValue{
+										IntValue: 123,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			Key: "array-val",
+			Value: &otlpcommon.AnyValue{
+				Value: &otlpcommon.AnyValue_ArrayValue{
+					ArrayValue: &otlpcommon.ArrayValue{
+						Values: []*otlpcommon.AnyValue{
+							{
+								Value: &otlpcommon.AnyValue_IntValue{
+									IntValue: 123,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			Key: attributeServiceName,
+			Value: &otlpcommon.AnyValue{
+				Value: &otlpcommon.AnyValue_StringValue{
+					StringValue: "service-name",
+				},
+			},
+		},
+	}
+
+	expected := []model.KeyValue{
+		{
+			Key:   "bool-val",
+			VType: model.ValueType_BOOL,
+			VBool: true,
+		},
+		{
+			Key:    "int-val",
+			VType:  model.ValueType_INT64,
+			VInt64: 123,
+		},
+		{
+			Key:   "string-val",
+			VType: model.ValueType_STRING,
+			VStr:  "abc",
+		},
+		{
+			Key:      "double-val",
+			VType:    model.ValueType_FLOAT64,
+			VFloat64: 1.23,
+		},
+		{
+			Key:   "map-val",
+			VType: model.ValueType_STRING,
+			VStr:  `{"key-map-val":123}`,
+		},
+		{
+			Key:   "array-val",
+			VType: model.ValueType_STRING,
+			VStr:  "[123]",
+		},
+		{
+			Key:   attributeServiceName,
+			VType: model.ValueType_STRING,
+			VStr:  "service-name",
+		},
+	}
+
+	gotTags := appendTagsFromAttributes(make([]model.KeyValue, 0, len(expected)), attributes)
+	require.EqualValues(t, expected, gotTags)
+
+	// The last item in expected ("service-name") must be skipped in resource tags translation
+	gotResourceTags, getServiceName := appendTagsFromResourceAttributes(attributes)
+	require.EqualValues(t, expected[:len(expected)-1], gotResourceTags)
+	require.EqualValues(t, "service-name", getServiceName)
+}
+
+func TestInternalTracesToJaegerProto(t *testing.T) {
+	tests := []struct {
+		name   string
+		td     otlpcoltrace.ExportTraceServiceRequest
+		jb     splunksapm.PostSpansRequest
+		hasErr bool
+	}{
+		{
+			name: "empty",
+			td: otlpcoltrace.ExportTraceServiceRequest{
+				ResourceSpans: []*otlptrace.ResourceSpans(nil),
+			},
+		},
+
+		{
+			name: "no-spans",
+			td: otlpcoltrace.ExportTraceServiceRequest{
+				ResourceSpans: []*otlptrace.ResourceSpans{
+					{
+						Resource: generateOtlpResource(),
+					},
+					{
+						Resource: generateOtlpResource(),
+						InstrumentationLibrarySpans: []*otlptrace.InstrumentationLibrarySpans{
+							nil,
+							{},
+							{
+								Spans: []*otlptrace.Span{
+									nil,
+								},
+							},
+						},
+					},
+					nil,
+				},
+			},
+			jb: splunksapm.PostSpansRequest{
+				Batches: []*model.Batch{},
+			},
+		},
+
+		{
+			name: "no-resource-attrs",
+			td: otlpcoltrace.ExportTraceServiceRequest{
+				ResourceSpans: []*otlptrace.ResourceSpans{
+					{
+						Resource: &otlpresource.Resource{},
+						InstrumentationLibrarySpans: []*otlptrace.InstrumentationLibrarySpans{
+							{
+								Spans: []*otlptrace.Span{
+									generateOtlpSpan(),
+								},
+							},
+						},
+					},
+				},
+			},
+			jb: splunksapm.PostSpansRequest{
+				Batches: []*model.Batch{
+					{
+						Process: &model.Process{
+							ServiceName: resourceNoServiceName,
+						},
+						Spans: []*model.Span{
+							generateProtoSpan(),
+						},
+					},
+				},
+			},
+		},
+
+		{
+			name: "one-span-with-trace-state",
+			td: otlpcoltrace.ExportTraceServiceRequest{
+				ResourceSpans: []*otlptrace.ResourceSpans{
+					{
+						InstrumentationLibrarySpans: []*otlptrace.InstrumentationLibrarySpans{
+							{
+								Spans: []*otlptrace.Span{
+									generateOtlpSpanWithTraceState(),
+								},
+							},
+						},
+					},
+				},
+			},
+			jb: splunksapm.PostSpansRequest{
+				Batches: []*model.Batch{
+					{
+						Process: &model.Process{
+							ServiceName: resourceNotSet,
+						},
+						Spans: []*model.Span{
+							generateProtoSpanWithTraceState(),
+						},
+					},
+				},
+			},
+		},
+
+		{
+			name: "library-info",
+			td: otlpcoltrace.ExportTraceServiceRequest{
+				ResourceSpans: []*otlptrace.ResourceSpans{
+					{
+						InstrumentationLibrarySpans: []*otlptrace.InstrumentationLibrarySpans{
+							{
+								InstrumentationLibrary: &otlpcommon.InstrumentationLibrary{
+									Name:    "io.opentelemetry.test",
+									Version: "0.42.0",
+								},
+								Spans: []*otlptrace.Span{
+									generateOtlpSpan(),
+								},
+							},
+						},
+					},
+				},
+			},
+			jb: splunksapm.PostSpansRequest{
+				Batches: []*model.Batch{
+					{
+						Process: &model.Process{
+							ServiceName: resourceNotSet,
+						},
+						Spans: []*model.Span{
+							generateProtoSpanWithLibraryInfo("io.opentelemetry.test"),
+						},
+					},
+				},
+			},
+		},
+
+		{
+			name: "two-spans-child-parent",
+			td: otlpcoltrace.ExportTraceServiceRequest{
+				ResourceSpans: []*otlptrace.ResourceSpans{
+					{
+						Resource: generateOtlpResource(),
+						InstrumentationLibrarySpans: []*otlptrace.InstrumentationLibrarySpans{
+							{
+								Spans: []*otlptrace.Span{
+									generateOtlpSpan(),
+									generateOtlpChildSpan(),
+								},
+							},
+						},
+					},
+				},
+			},
+			jb: splunksapm.PostSpansRequest{
+				Batches: []*model.Batch{
+					{
+						Process: generateProtoProcess(),
+						Spans: []*model.Span{
+							generateProtoSpan(),
+							generateProtoChildSpanWithErrorTags(),
+						},
+					},
+				},
+			},
+		},
+
+		{
+			name: "two-spans-with-follower",
+			td: otlpcoltrace.ExportTraceServiceRequest{
+				ResourceSpans: []*otlptrace.ResourceSpans{
+					{
+						Resource: generateOtlpResource(),
+						InstrumentationLibrarySpans: []*otlptrace.InstrumentationLibrarySpans{
+							{
+								Spans: []*otlptrace.Span{
+									generateOtlpSpan(),
+									generateOtlpFollowerSpan(),
+								},
+							},
+						},
+					},
+				},
+			},
+			jb: splunksapm.PostSpansRequest{
+				Batches: []*model.Batch{
+					{
+						Process: generateProtoProcess(),
+						Spans: []*model.Span{
+							generateProtoSpan(),
+							generateProtoFollowerSpan(),
+						},
+					},
+				},
+			},
+		},
+
+		{
+			name: "root-span-nil-links-no-tags",
+			td: otlpcoltrace.ExportTraceServiceRequest{
+				ResourceSpans: []*otlptrace.ResourceSpans{
+					{
+						Resource: generateOtlpResource(),
+						InstrumentationLibrarySpans: []*otlptrace.InstrumentationLibrarySpans{
+							{
+								Spans: []*otlptrace.Span{
+									{
+										TraceId: []byte{0xF1, 0xF2, 0xF3, 0xF4, 0xF5, 0xF6, 0xF7, 0xF8, 0xF9, 0xFA, 0xFB, 0xFC, 0xFD, 0xFE, 0xFF, 0x80},
+										SpanId:  []byte{0xAF, 0xAE, 0xAD, 0xAC, 0xAB, 0xAA, 0xA9, 0xA8},
+										Links: []*otlptrace.Span_Link{
+											nil,
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			jb: splunksapm.PostSpansRequest{
+				Batches: []*model.Batch{
+					{
+						Process: generateProtoProcess(),
+						Spans: []*model.Span{
+							{
+								TraceID: model.NewTraceID(
+									binary.BigEndian.Uint64([]byte{0xF1, 0xF2, 0xF3, 0xF4, 0xF5, 0xF6, 0xF7, 0xF8}),
+									binary.BigEndian.Uint64([]byte{0xF9, 0xFA, 0xFB, 0xFC, 0xFD, 0xFE, 0xFF, 0x80}),
+								),
+								SpanID: model.NewSpanID(binary.BigEndian.Uint64([]byte{0xAF, 0xAE, 0xAD, 0xAC, 0xAB, 0xAA, 0xA9, 0xA8})),
+							},
+						},
+					},
+				},
+			},
+		},
+
+		{
+			name: "error-trace-id",
+			td: otlpcoltrace.ExportTraceServiceRequest{
+				ResourceSpans: []*otlptrace.ResourceSpans{
+					{
+						InstrumentationLibrarySpans: []*otlptrace.InstrumentationLibrarySpans{
+							{
+								Spans: []*otlptrace.Span{
+									{
+										TraceId: []byte{1, 2},
+										SpanId:  []byte{0xAF, 0xAE, 0xAD, 0xAC, 0xAB, 0xAA, 0xA9, 0xA8},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			hasErr: true,
+		},
+
+		{
+			name: "error-span-id",
+			td: otlpcoltrace.ExportTraceServiceRequest{
+				ResourceSpans: []*otlptrace.ResourceSpans{
+					{
+						InstrumentationLibrarySpans: []*otlptrace.InstrumentationLibrarySpans{
+							{
+								Spans: []*otlptrace.Span{
+									{
+										TraceId: []byte{0xF1, 0xF2, 0xF3, 0xF4, 0xF5, 0xF6, 0xF7, 0xF8, 0xF9, 0xFA, 0xFB, 0xFC, 0xFD, 0xFE, 0xFF, 0x80},
+										SpanId:  []byte{1, 2},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			hasErr: true,
+		},
+
+		{
+			name: "error-parent-span-id",
+			td: otlpcoltrace.ExportTraceServiceRequest{
+				ResourceSpans: []*otlptrace.ResourceSpans{
+					{
+						InstrumentationLibrarySpans: []*otlptrace.InstrumentationLibrarySpans{
+							{
+								Spans: []*otlptrace.Span{
+									{
+										TraceId:      []byte{0xF1, 0xF2, 0xF3, 0xF4, 0xF5, 0xF6, 0xF7, 0xF8, 0xF9, 0xFA, 0xFB, 0xFC, 0xFD, 0xFE, 0xFF, 0x80},
+										SpanId:       []byte{0xAF, 0xAE, 0xAD, 0xAC, 0xAB, 0xAA, 0xA9, 0xA8},
+										ParentSpanId: []byte{1, 2},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			hasErr: true,
+		},
+
+		{
+			name: "error-linked-trace-id",
+			td: otlpcoltrace.ExportTraceServiceRequest{
+				ResourceSpans: []*otlptrace.ResourceSpans{
+					{
+						InstrumentationLibrarySpans: []*otlptrace.InstrumentationLibrarySpans{
+							{
+								Spans: []*otlptrace.Span{
+									{
+										TraceId: []byte{0xF1, 0xF2, 0xF3, 0xF4, 0xF5, 0xF6, 0xF7, 0xF8, 0xF9, 0xFA, 0xFB, 0xFC, 0xFD, 0xFE, 0xFF, 0x80},
+										SpanId:  []byte{0xAF, 0xAE, 0xAD, 0xAC, 0xAB, 0xAA, 0xA9, 0xA8},
+										Links: []*otlptrace.Span_Link{
+											{
+												TraceId: []byte{1, 2},
+												SpanId:  []byte{0xAF, 0xAE, 0xAD, 0xAC, 0xAB, 0xAA, 0xA9, 0xA8},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			hasErr: true,
+		},
+
+		{
+			name: "error-linked-span-id",
+			td: otlpcoltrace.ExportTraceServiceRequest{
+				ResourceSpans: []*otlptrace.ResourceSpans{
+					{
+						InstrumentationLibrarySpans: []*otlptrace.InstrumentationLibrarySpans{
+							{
+								Spans: []*otlptrace.Span{
+									{
+										TraceId: []byte{0xF1, 0xF2, 0xF3, 0xF4, 0xF5, 0xF6, 0xF7, 0xF8, 0xF9, 0xFA, 0xFB, 0xFC, 0xFD, 0xFE, 0xFF, 0x80},
+										SpanId:  []byte{0xAF, 0xAE, 0xAD, 0xAC, 0xAB, 0xAA, 0xA9, 0xA8},
+										Links: []*otlptrace.Span_Link{
+											{
+												TraceId: []byte{0xF1, 0xF2, 0xF3, 0xF4, 0xF5, 0xF6, 0xF7, 0xF8, 0xF9, 0xFA, 0xFB, 0xFC, 0xFD, 0xFE, 0xFF, 0x80},
+												SpanId:  []byte{1, 2},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			hasErr: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			jbs, err := otlpToSAPM(test.td)
+			if test.hasErr {
+				assert.Error(t, err)
+				assert.Nil(t, jbs)
+				return
+			}
+			assert.NoError(t, err)
+			assert.EqualValues(t, &test.jb, jbs)
+		})
+	}
+}
+
+func generateProtoChildSpanWithErrorTags() *model.Span {
+	span := generateProtoChildSpan()
+	span.Tags = append(span.Tags, model.KeyValue{
+		Key:    tagStatusCode,
+		VType:  model.ValueType_INT64,
+		VInt64: int64(otlptrace.Status_STATUS_CODE_NOT_FOUND),
+	})
+	span.Tags = append(span.Tags, model.KeyValue{
+		Key:   tagError,
+		VBool: true,
+		VType: model.ValueType_BOOL,
+	})
+	return span
+}
+
+func BenchmarkInternalTracesToJaegerProto(b *testing.B) {
+	td := otlpcoltrace.ExportTraceServiceRequest{
+		ResourceSpans: []*otlptrace.ResourceSpans{
+			{
+				Resource: generateOtlpResource(),
+				InstrumentationLibrarySpans: []*otlptrace.InstrumentationLibrarySpans{
+					{
+						Spans: []*otlptrace.Span{
+							generateOtlpSpan(),
+							generateOtlpFollowerSpan(),
+						},
+					},
+				},
+			},
+		},
+	}
+
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		_, err := otlpToSAPM(td)
+		assert.NoError(b, err)
+	}
+}
+
+func generateProtoProcess() *model.Process {
+	return &model.Process{
+		ServiceName: "service",
+		Tags: []model.KeyValue{
+			{
+				Key:    "int-attr",
+				VType:  model.ValueType_INT64,
+				VInt64: 123,
+			},
+		},
+	}
+}
+
+func generateProtoSpan() *model.Span {
+	return &model.Span{
+		TraceID: model.NewTraceID(
+			binary.BigEndian.Uint64([]byte{0xF1, 0xF2, 0xF3, 0xF4, 0xF5, 0xF6, 0xF7, 0xF8}),
+			binary.BigEndian.Uint64([]byte{0xF9, 0xFA, 0xFB, 0xFC, 0xFD, 0xFE, 0xFF, 0x80}),
+		),
+		SpanID:        model.NewSpanID(binary.BigEndian.Uint64([]byte{0xAF, 0xAE, 0xAD, 0xAC, 0xAB, 0xAA, 0xA9, 0xA8})),
+		OperationName: "operationA",
+		StartTime:     testSpanStartTime,
+		Duration:      testSpanEndTime.Sub(testSpanStartTime),
+		Logs: []model.Log{
+			{
+				Timestamp: testSpanEventTime,
+				Fields: []model.KeyValue{
+					{
+						Key:   tagMessage,
+						VType: model.ValueType_STRING,
+						VStr:  "event-with-attr",
+					},
+					{
+						Key:   "span-event-attr",
+						VType: model.ValueType_STRING,
+						VStr:  "span-event-attr-val",
+					},
+				},
+			},
+			{
+				Timestamp: testSpanEventTime,
+				Fields: []model.KeyValue{
+					{
+						Key:    "attr-int",
+						VType:  model.ValueType_INT64,
+						VInt64: 123,
+					},
+				},
+			},
+		},
+		Tags: []model.KeyValue{
+			{
+				Key:   tagSpanKind,
+				VType: model.ValueType_STRING,
+				VStr:  openTracingSpanKindClient,
+			},
+			{
+				Key:    tagStatusCode,
+				VType:  model.ValueType_INT64,
+				VInt64: int64(otlptrace.Status_STATUS_CODE_CANCELLED),
+			},
+			{
+				Key:   tagError,
+				VBool: true,
+				VType: model.ValueType_BOOL,
+			},
+			{
+				Key:   tagStatusMsg,
+				VType: model.ValueType_STRING,
+				VStr:  "status-cancelled",
+			},
+		},
+	}
+}
+
+func generateProtoChildSpan() *model.Span {
+	traceID := model.NewTraceID(
+		binary.BigEndian.Uint64([]byte{0xF1, 0xF2, 0xF3, 0xF4, 0xF5, 0xF6, 0xF7, 0xF8}),
+		binary.BigEndian.Uint64([]byte{0xF9, 0xFA, 0xFB, 0xFC, 0xFD, 0xFE, 0xFF, 0x80}),
+	)
+	return &model.Span{
+		TraceID:       traceID,
+		SpanID:        model.NewSpanID(binary.BigEndian.Uint64([]byte{0x1F, 0x1E, 0x1D, 0x1C, 0x1B, 0x1A, 0x19, 0x18})),
+		OperationName: "operationB",
+		StartTime:     testSpanStartTime,
+		Duration:      testSpanEndTime.Sub(testSpanStartTime),
+		Tags: []model.KeyValue{
+			{
+				Key:    tagHTTPStatusCode,
+				VType:  model.ValueType_INT64,
+				VInt64: 404,
+			},
+			{
+				Key:   tagSpanKind,
+				VType: model.ValueType_STRING,
+				VStr:  openTracingSpanKindServer,
+			},
+		},
+		References: []model.SpanRef{
+			{
+				TraceID: traceID,
+				SpanID:  model.NewSpanID(binary.BigEndian.Uint64([]byte{0xAF, 0xAE, 0xAD, 0xAC, 0xAB, 0xAA, 0xA9, 0xA8})),
+				RefType: model.SpanRefType_CHILD_OF,
+			},
+		},
+	}
+}
+
+func generateProtoFollowerSpan() *model.Span {
+	traceID := model.NewTraceID(
+		binary.BigEndian.Uint64([]byte{0xF1, 0xF2, 0xF3, 0xF4, 0xF5, 0xF6, 0xF7, 0xF8}),
+		binary.BigEndian.Uint64([]byte{0xF9, 0xFA, 0xFB, 0xFC, 0xFD, 0xFE, 0xFF, 0x80}),
+	)
+	return &model.Span{
+		TraceID:       traceID,
+		SpanID:        model.NewSpanID(binary.BigEndian.Uint64([]byte{0x1F, 0x1E, 0x1D, 0x1C, 0x1B, 0x1A, 0x19, 0x18})),
+		OperationName: "operationC",
+		StartTime:     testSpanEndTime,
+		Duration:      time.Millisecond,
+		Tags: []model.KeyValue{
+			{
+				Key:   tagSpanKind,
+				VType: model.ValueType_STRING,
+				VStr:  openTracingSpanKindConsumer,
+			},
+			{
+				Key:    tagStatusCode,
+				VType:  model.ValueType_INT64,
+				VInt64: int64(otlptrace.Status_STATUS_CODE_OK),
+			},
+			{
+				Key:   tagStatusMsg,
+				VType: model.ValueType_STRING,
+				VStr:  "status-ok",
+			},
+		},
+		References: []model.SpanRef{
+			{
+				TraceID: traceID,
+				SpanID:  model.NewSpanID(binary.BigEndian.Uint64([]byte{0xAF, 0xAE, 0xAD, 0xAC, 0xAB, 0xAA, 0xA9, 0xA8})),
+				RefType: model.SpanRefType_FOLLOWS_FROM,
+			},
+		},
+	}
+}
+
+func generateProtoSpanWithLibraryInfo(libraryName string) *model.Span {
+	span := generateProtoSpan()
+	span.Tags = append([]model.KeyValue{
+		{
+
+			Key:   tagInstrumentationName,
+			VType: model.ValueType_STRING,
+			VStr:  libraryName,
+		},
+		{
+			Key:   tagInstrumentationVersion,
+			VType: model.ValueType_STRING,
+			VStr:  "0.42.0",
+		},
+	}, span.Tags...)
+
+	return span
+}
+
+func generateProtoSpanWithTraceState() *model.Span {
+	span := generateProtoSpan()
+	span.Tags = []model.KeyValue{
+		{
+			Key:   tagSpanKind,
+			VType: model.ValueType_STRING,
+			VStr:  openTracingSpanKindClient,
+		},
+		{
+			Key:   tagW3CTraceState,
+			VType: model.ValueType_STRING,
+			VStr:  "lasterror=f39cd56cc44274fd5abd07ef1164246d10ce2955",
+		},
+	}
+	return span
+}
+
+func generateOtlpResource() *otlpresource.Resource {
+	return &otlpresource.Resource{
+		Attributes: []*otlpcommon.KeyValue{
+			{
+				Key:   attributeServiceName,
+				Value: &otlpcommon.AnyValue{Value: &otlpcommon.AnyValue_StringValue{StringValue: "service"}},
+			},
+			{
+				Key:   "int-attr",
+				Value: &otlpcommon.AnyValue{Value: &otlpcommon.AnyValue_IntValue{IntValue: 123}},
+			},
+		},
+	}
+}
+
+func generateOtlpSpan() *otlptrace.Span {
+	span := &otlptrace.Span{}
+	span.SpanId = []byte{0xAF, 0xAE, 0xAD, 0xAC, 0xAB, 0xAA, 0xA9, 0xA8}
+	span.TraceId = []byte{0xF1, 0xF2, 0xF3, 0xF4, 0xF5, 0xF6, 0xF7, 0xF8, 0xF9, 0xFA, 0xFB, 0xFC, 0xFD, 0xFE, 0xFF, 0x80}
+	span.Name = "operationA"
+	span.StartTimeUnixNano = uint64(testSpanStartTimestamp)
+	span.EndTimeUnixNano = uint64(testSpanEndTimestamp)
+	span.Kind = otlptrace.Span_SPAN_KIND_CLIENT
+	span.Events = []*otlptrace.Span_Event{
+		{
+			TimeUnixNano: uint64(testSpanEventTimestamp),
+			Name:         "event-with-attr",
+			Attributes: []*otlpcommon.KeyValue{
+				{
+					Key:   "span-event-attr",
+					Value: &otlpcommon.AnyValue{Value: &otlpcommon.AnyValue_StringValue{StringValue: "span-event-attr-val"}},
+				},
+			},
+		},
+		{
+			TimeUnixNano: uint64(testSpanEventTimestamp),
+			Attributes: []*otlpcommon.KeyValue{
+				{
+					Key:   "attr-int",
+					Value: &otlpcommon.AnyValue{Value: &otlpcommon.AnyValue_IntValue{IntValue: 123}},
+				},
+			},
+		},
+	}
+	span.Status = &otlptrace.Status{
+		Code:    otlptrace.Status_STATUS_CODE_CANCELLED,
+		Message: "status-cancelled",
+	}
+	return span
+}
+
+func generateOtlpChildSpan() *otlptrace.Span {
+	span := generateOtlpSpan()
+	originalSpanID := span.SpanId
+	span.Name = "operationB"
+	span.SpanId = []byte{0x1F, 0x1E, 0x1D, 0x1C, 0x1B, 0x1A, 0x19, 0x18}
+	span.ParentSpanId = originalSpanID
+	span.Kind = otlptrace.Span_SPAN_KIND_SERVER
+	span.Status = &otlptrace.Status{
+		Code: otlptrace.Status_STATUS_CODE_NOT_FOUND,
+	}
+	span.Events = nil
+	span.Attributes = []*otlpcommon.KeyValue{
+		{
+			Key:   tagHTTPStatusCode,
+			Value: &otlpcommon.AnyValue{Value: &otlpcommon.AnyValue_IntValue{IntValue: 404}},
+		},
+	}
+
+	return span
+}
+
+func generateOtlpFollowerSpan() *otlptrace.Span {
+	span := generateOtlpSpan()
+	originalSpanID := span.SpanId
+	span.Name = "operationC"
+	span.SpanId = []byte{0x1F, 0x1E, 0x1D, 0x1C, 0x1B, 0x1A, 0x19, 0x18}
+	span.StartTimeUnixNano = span.EndTimeUnixNano
+	span.EndTimeUnixNano = span.EndTimeUnixNano + 1000000
+	span.Kind = otlptrace.Span_SPAN_KIND_CONSUMER
+	span.Events = []*otlptrace.Span_Event{
+		nil,
+	}
+	span.Status = &otlptrace.Status{
+		Code:    otlptrace.Status_STATUS_CODE_OK,
+		Message: "status-ok",
+	}
+	span.Links = []*otlptrace.Span_Link{
+		{
+			TraceId: span.TraceId,
+			SpanId:  originalSpanID,
+		},
+	}
+	return span
+}
+
+func generateOtlpSpanWithTraceState() *otlptrace.Span {
+	span := generateOtlpSpan()
+	span.Status = nil
+	span.TraceState = "lasterror=f39cd56cc44274fd5abd07ef1164246d10ce2955"
+	span.Attributes = nil
+	return span
+}


### PR DESCRIPTION
Code was inspired from the otel-collector because the code in the collector
cannot be consumed as a library and there are too many dependecies to bring.

Signed-off-by: Bogdan Drutu <bogdandrutu@gmail.com>

Split from https://github.com/signalfx/sapm-proto/pull/25
Depends on https://github.com/signalfx/sapm-proto/pull/27