### PR TITLE
Add OTLP helper to parse http request, and transform to SAPM

### DIFF
--- a/otlp/parser.go
+++ b/otlp/parser.go
@@ -1,0 +1,33 @@
+// Copyright 2020 Splunk, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package otlp
+
+import (
+	"net/http"
+
+	splunksapm "github.com/signalfx/sapm-proto/gen"
+	otlpcoltrace "github.com/signalfx/sapm-proto/gen/otlp/collector/trace/v1"
+	"github.com/signalfx/sapm-proto/sapmprotocol"
+)
+
+// ParseRequest parses from the request (unzip if needed) an OTLP protobuf,
+// and converts it to SAPM.
+func ParseRequest(req *http.Request) (*splunksapm.PostSpansRequest, error) {
+	otlp := otlpcoltrace.ExportTraceServiceRequest{}
+	if err := sapmprotocol.ParseSapmRequest(req, &otlp); err != nil {
+		return nil, err
+	}
+	return otlpToSAPM(otlp)
+}

--- a/otlp/parser.go
+++ b/otlp/parser.go
@@ -22,7 +22,7 @@ import (
 	"github.com/signalfx/sapm-proto/sapmprotocol"
 )
 
-// ParseRequest parses from the request (unzip if needed) an OTLP protobuf,
+// ParseRequest parses from the request (unzip if needed) from OTLP protobuf,
 // and converts it to SAPM.
 func ParseRequest(req *http.Request) (*splunksapm.PostSpansRequest, error) {
 	otlp := otlpcoltrace.ExportTraceServiceRequest{}

--- a/otlp/parser_test.go
+++ b/otlp/parser_test.go
@@ -1,0 +1,72 @@
+// Copyright 2020 Splunk, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package otlp
+
+import (
+	"bytes"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/jaegertracing/jaeger/model"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	splunksapm "github.com/signalfx/sapm-proto/gen"
+	otlpcoltrace "github.com/signalfx/sapm-proto/gen/otlp/collector/trace/v1"
+	otlptrace "github.com/signalfx/sapm-proto/gen/otlp/trace/v1"
+)
+
+func TestParseRequest(t *testing.T) {
+	otlp := otlpcoltrace.ExportTraceServiceRequest{
+		ResourceSpans: []*otlptrace.ResourceSpans{
+			{
+				Resource: generateOtlpResource(),
+				InstrumentationLibrarySpans: []*otlptrace.InstrumentationLibrarySpans{
+					{
+						Spans: []*otlptrace.Span{
+							generateOtlpSpan(),
+						},
+					},
+				},
+			},
+		},
+	}
+	expected := splunksapm.PostSpansRequest{
+		Batches: []*model.Batch{
+			{
+				Process: generateProtoProcess(),
+				Spans: []*model.Span{
+					generateProtoSpan(),
+				},
+			},
+		},
+	}
+	reqBody, err := otlp.Marshal()
+	require.NoError(t, err)
+
+	req := httptest.NewRequest("GET", "http://signalfx.com/v1/traces", bytes.NewReader(reqBody))
+	var sapm *splunksapm.PostSpansRequest
+	sapm, err = ParseRequest(req)
+	// No "Content-Type".
+	assert.Error(t, err)
+	assert.Nil(t, sapm)
+
+	req = httptest.NewRequest("GET", "http://signalfx.com/v1/traces", bytes.NewReader(reqBody))
+	req.Header["Content-Type"] = []string{"application/x-protobuf"}
+	sapm, err = ParseRequest(req)
+	// No "Content-Type".
+	assert.NoError(t, err)
+	assert.EqualValues(t, &expected, sapm)
+}

--- a/otlp/parser_test.go
+++ b/otlp/parser_test.go
@@ -66,7 +66,6 @@ func TestParseRequest(t *testing.T) {
 	req = httptest.NewRequest("GET", "http://signalfx.com/v1/traces", bytes.NewReader(reqBody))
 	req.Header["Content-Type"] = []string{"application/x-protobuf"}
 	sapm, err = ParseRequest(req)
-	// No "Content-Type".
 	assert.NoError(t, err)
 	assert.EqualValues(t, &expected, sapm)
 }


### PR DESCRIPTION
Signed-off-by: Bogdan Drutu <bogdandrutu@gmail.com>

Split from https://github.com/signalfx/sapm-proto/pull/25
Depends on https://github.com/signalfx/sapm-proto/pull/28