### PR TITLE
Add Splunk notice to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,3 +9,5 @@ SAPM (Splunk APM Protocol) ProtoBuf schema.
 Schema definition is in samp.proto and imports Jaeger model.proto that is vendored.
 
 Use `make` to generate Go ProtoBuf code.
+
+>ℹ️&nbsp;&nbsp;SignalFx was acquired by Splunk in October 2019. See [Splunk SignalFx](https://www.splunk.com/en_us/investor-relations/acquisitions/signalfx.html) for more information.


### PR DESCRIPTION
This small PR adds the acquisition notice with a link to the README file.