### PR TITLE
Mark error return by prepare as permanent

### DIFF
--- a/client/worker.go
+++ b/client/worker.go
@@ -81,7 +81,7 @@ func (w *worker) export(ctx context.Context, batches []*jaegerpb.Batch, accessTo
 		span.RecordError(err)
 		span.SetStatus(codes.Error, "")
 		recordEncodingFailure(ctx, sr)
-		return &ErrSend{Err: err}
+		return &ErrSend{Err: err, Permanent: true}
 	}
 
 	serr := w.send(ctx, sr, accessToken)


### PR DESCRIPTION
The errors are: marshaling or gzipping which both will fail in case of a retry.

Signed-off-by: Bogdan Drutu <bogdandrutu@gmail.com>