### PR TITLE
Attempt to make test less unstable

### DIFF
--- a/client/client_test.go
+++ b/client/client_test.go
@@ -406,6 +406,6 @@ func TestPauses(t *testing.T) {
 
 	wg.Wait()
 	for _, e := range elapsed {
-		assert.True(t, e >= time.Second*time.Duration(retryDelaySeconds))
+		assert.True(t, e >= time.Duration(retryDelaySeconds))
 	}
 }


### PR DESCRIPTION
```
❯ go test -run TestPauses -count 100
PASS
ok      github.com/signalfx/sapm-proto/client   200.431s

```

This test appears to be more stable when the comparison is done in millisecond as opposed to seconds.