### PR TITLE
Add zstd decompression support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -26,6 +26,7 @@ require (
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.7.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
+	github.com/klauspost/compress v1.16.5 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal v0.60.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -151,6 +151,8 @@ github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1
 github.com/jstemmer/go-junit-report v0.9.1/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/XSXhF0NWZEnDohbsk=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
+github.com/klauspost/compress v1.16.5 h1:IFV2oUNUzZaz+XyusxpLzpzS8Pt5rh0Z16For/djlyI=
+github.com/klauspost/compress v1.16.5/go.mod h1:ntbaceVETuRiXiv4DpjP66DpAtAGkEQskQzEyD//IeE=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pretty v0.3.0 h1:WgNl7dwNpEZ6jJ9k1snq4pZsg7DOEN8hP9Xw0Tsjwk0=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=

--- a/sapmprotocol/constants.go
+++ b/sapmprotocol/constants.go
@@ -28,4 +28,6 @@ const (
 	ContentEncodingHeaderName = "Content-Encoding"
 	// GZipEncodingHeaderValue is the value used for gzipped encoding http headers
 	GZipEncodingHeaderValue = "gzip"
+	// ZStdEncodingHeaderValue is the value used for zstd-compressed encoding http headers
+	ZStdEncodingHeaderValue = "zstd"
 )


### PR DESCRIPTION
## Changes Made

### zstd decompression

Added support for zstd decompression, indicated by "Content-Encoding: zstd" http request header.

### New benchmark

Added a new benchmark that performs decoding of various batch sizes using all 3  supported Content-Encodings. Benchmark results show zstd uses less CPU than GZIP for all batch sizes:

```
name                            time/op
DecodeMatrix/none/batch=1-8     3.35µs ± 3%
DecodeMatrix/gzip/batch=1-8     6.26µs ± 1%
DecodeMatrix/zstd/batch=1-8     4.45µs ± 4%
DecodeMatrix/none/batch=10-8    12.2µs ± 0%
DecodeMatrix/gzip/batch=10-8    23.4µs ± 3%
DecodeMatrix/zstd/batch=10-8    15.5µs ± 5%
DecodeMatrix/none/batch=100-8    100µs ±10%
DecodeMatrix/gzip/batch=100-8    141µs ±10%
DecodeMatrix/zstd/batch=100-8    123µs ± 4%
DecodeMatrix/none/batch=1000-8   964µs ± 5%
DecodeMatrix/gzip/batch=1000-8  1.30ms ± 4%
DecodeMatrix/zstd/batch=1000-8  1.00ms ± 4%

name                            alloc/op
DecodeMatrix/none/batch=1-8     6.84kB ± 0%
DecodeMatrix/gzip/batch=1-8     11.1kB ± 0%
DecodeMatrix/zstd/batch=1-8     6.87kB ± 0%
DecodeMatrix/none/batch=10-8    18.8kB ± 0%
DecodeMatrix/gzip/batch=10-8    23.2kB ± 0%
DecodeMatrix/zstd/batch=10-8    18.9kB ± 0%
DecodeMatrix/none/batch=100-8    138kB ± 0%
DecodeMatrix/gzip/batch=100-8    144kB ± 0%
DecodeMatrix/zstd/batch=100-8    139kB ± 0%
DecodeMatrix/none/batch=1000-8  1.34MB ± 0%
DecodeMatrix/gzip/batch=1000-8  1.35MB ± 0%
DecodeMatrix/zstd/batch=1000-8  1.39MB ± 1%

name                            allocs/op
DecodeMatrix/none/batch=1-8       36.0 ± 0%
DecodeMatrix/gzip/batch=1-8       39.0 ± 0%
DecodeMatrix/zstd/batch=1-8       37.0 ± 0%
DecodeMatrix/none/batch=10-8       157 ± 0%
DecodeMatrix/gzip/batch=10-8       160 ± 0%
DecodeMatrix/zstd/batch=10-8       158 ± 0%
DecodeMatrix/none/batch=100-8    1.33k ± 0%
DecodeMatrix/gzip/batch=100-8    1.37k ± 0%
DecodeMatrix/zstd/batch=100-8    1.33k ± 0%
DecodeMatrix/none/batch=1000-8   13.0k ± 0%
DecodeMatrix/gzip/batch=1000-8   13.1k ± 0%
DecodeMatrix/zstd/batch=1000-8   13.0k ± 0%
```

### Eliminated tmp buffer

Removed `tmp` field from pool object and eliminated io.CopyBuffer. This is not necessary since io.CopyBuffer does not use a temp buffer if either dest or src are capable of ReadFrom/WriteTo shortcut (see https://cs.opensource.google/go/go/+/master:src/io/io.go;drc=1ff89009f198ad5bae3549dd3b992882bd97e5f8;l=411)

We now use io.Copy instead. Benchmarking before and after the change shows that there is no performance change. I kept the existing BenchmarkDecode function to make sure we can easily compare the performance before and after.

Performance Comparison:

```
name      old time/op    new time/op    delta
Decode-8    72.5µs ± 2%    71.3µs ± 2%    ~     (p=0.210 n=10+10)

name      old alloc/op   new alloc/op   delta
Decode-8    83.3kB ± 0%    83.0kB ± 0%  -0.46%  (p=0.000 n=10+10)

name      old allocs/op  new allocs/op  delta
Decode-8     1.08k ± 0%     1.08k ± 0%    ~     (all equal)
```