### PR TITLE
Add zstd compression support to SAPM client

### DIFF
--- a/client/oc_status_code.go
+++ b/client/oc_status_code.go
@@ -43,7 +43,6 @@ const (
 	headerRetryAfter                  = "Retry-After"
 	headerContentEncoding             = "Content-Encoding"
 	headerContentType                 = "Content-Type"
-	headerValueGZIP                   = "gzip"
 	headerValueXProtobuf              = "application/x-protobuf"
 )
 

--- a/client/options.go
+++ b/client/options.go
@@ -15,6 +15,7 @@
 package client
 
 import (
+	"fmt"
 	"net/http"
 
 	"go.opentelemetry.io/otel/trace"
@@ -64,10 +65,26 @@ func WithAccessToken(t string) Option {
 	}
 }
 
-// WithDisabledCompression configures the client to not apply GZip compression on the outgoing requests.
+// WithDisabledCompression configures the client to not apply compression on the outgoing requests.
 func WithDisabledCompression() Option {
 	return func(a *Client) error {
 		a.disableCompression = true
+		return nil
+	}
+}
+
+// WithCompressionMethod chooses the compression method for the outgoing requests.
+// The default compression method is CompressionMethodGzip.
+// This option is ignored if WithDisabledCompression() is used.
+func WithCompressionMethod(compressionMethod CompressionMethod) Option {
+	return func(a *Client) error {
+		switch compressionMethod {
+		case CompressionMethodGzip, CompressionMethodZstd:
+			a.compressionMethod = compressionMethod
+		default:
+			return fmt.Errorf("invalid compression method %q", string(compressionMethod))
+		}
+
 		return nil
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/gogo/protobuf v1.3.2
 	github.com/golang/protobuf v1.5.2
 	github.com/jaegertracing/jaeger v1.38.0
+	github.com/klauspost/compress v1.16.5
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/jaeger v0.60.0
 	github.com/stretchr/testify v1.8.0
 	go.opencensus.io v0.23.0
@@ -26,7 +27,6 @@ require (
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.7.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
-	github.com/klauspost/compress v1.16.5 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal v0.60.0 // indirect

--- a/internal/testhelpers/testdata.go
+++ b/internal/testhelpers/testdata.go
@@ -1,0 +1,47 @@
+package testhelpers
+
+import (
+	"strconv"
+	"time"
+
+	"github.com/jaegertracing/jaeger/model"
+
+	splunksapm "github.com/signalfx/sapm-proto/gen"
+)
+
+func CreateSapmData(batchSize int) *splunksapm.PostSpansRequest {
+	attrs := []string{
+		"service.name", "shoppingcart", "host.name", "spool.example.com", "service.id",
+		"adb80442-8437-46b5-a637-ce4a158ba9cf",
+	}
+
+	batch := &model.Batch{
+		Process: &model.Process{ServiceName: "spring"},
+		Spans:   []*model.Span{},
+	}
+	for i := 0; i < batchSize; i++ {
+		span := &model.Span{
+			TraceID:       model.NewTraceID(uint64(i*5), uint64(i*10)),
+			SpanID:        model.NewSpanID(uint64(i)),
+			OperationName: "jonatan" + strconv.Itoa(i),
+			Duration:      time.Millisecond * time.Duration(i),
+			Tags: model.KeyValues{
+				{Key: "span.kind", VStr: "client", VType: model.StringType},
+			},
+			StartTime: time.Now().UTC().Add(time.Second * time.Duration(i)),
+		}
+		for j := 0; j < 2; j++ {
+			span.Tags = append(
+				span.Tags,
+				model.KeyValue{
+					Key:   attrs[(i+j)%len(attrs)],
+					VStr:  attrs[(i+j+1)%len(attrs)],
+					VType: model.StringType,
+				},
+			)
+		}
+
+		batch.Spans = append(batch.Spans, span)
+	}
+	return &splunksapm.PostSpansRequest{Batches: []*model.Batch{batch}}
+}

--- a/sapmprotocol/parser_test.go
+++ b/sapmprotocol/parser_test.go
@@ -34,6 +34,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	splunksapm "github.com/signalfx/sapm-proto/gen"
+	"github.com/signalfx/sapm-proto/internal/testhelpers"
 )
 
 func TestNewV2TraceHandler(t *testing.T) {
@@ -274,43 +275,6 @@ func BenchmarkDecode(b *testing.B) {
 	}
 }
 
-func createSapmData(batchSize int) *splunksapm.PostSpansRequest {
-	attrs := []string{
-		"service.name", "shoppingcart", "host.name", "spool.example.com", "service.id",
-		"adb80442-8437-46b5-a637-ce4a158ba9cf",
-	}
-
-	batch := &model.Batch{
-		Process: &model.Process{ServiceName: "spring"},
-		Spans:   []*model.Span{},
-	}
-	for i := 0; i < batchSize; i++ {
-		span := &model.Span{
-			TraceID:       model.NewTraceID(uint64(i*5), uint64(i*10)),
-			SpanID:        model.NewSpanID(uint64(i)),
-			OperationName: "jonatan" + strconv.Itoa(i),
-			Duration:      time.Millisecond * time.Duration(i),
-			Tags: model.KeyValues{
-				{Key: "span.kind", VStr: "client", VType: model.StringType},
-			},
-			StartTime: time.Now().UTC().Add(time.Second * time.Duration(i)),
-		}
-		for j := 0; j < 2; j++ {
-			span.Tags = append(
-				span.Tags,
-				model.KeyValue{
-					Key:   attrs[(i+j)%len(attrs)],
-					VStr:  attrs[(i+j+1)%len(attrs)],
-					VType: model.StringType,
-				},
-			)
-		}
-
-		batch.Spans = append(batch.Spans, span)
-	}
-	return &splunksapm.PostSpansRequest{Batches: []*model.Batch{batch}}
-}
-
 func zstdBytes(uncompressedBytes []byte) []byte {
 	buf := bytes.NewBuffer(nil)
 	w, err := zstd.NewWriter(buf)
@@ -382,7 +346,7 @@ func BenchmarkDecodeMatrix(b *testing.B) {
 	for _, batchSize := range batchSizes {
 
 		// Encode the batch to binary ProtoBuf.
-		sapmData := createSapmData(batchSize)
+		sapmData := testhelpers.CreateSapmData(batchSize)
 
 		uncompressedBytes, err := sapmData.Marshal()
 		if err != nil {


### PR DESCRIPTION
I added a simple benchmark of compression methods and a test to print compressed byte sizes. Take with a grain of salt since the input is based on just one trivial data generator and may not be representative of production loads.

For the inputs used zstd wins both in compression size and speed (more apparent in larger input sizes).

## Compression Sizes

```
=== RUN   TestCompressionSize
Message byte size by batch and compression method.
Compression       none      gzip      zstd
Batch=1            148       139       135
Batch=10          1558       503       490
Batch=100        15958      2495      2360
Batch=1000      161590     22110     22978
Batch=10000    1644106    222217    181468
--- PASS: TestCompressionSize (0.13s)
```

## Benchmark

```
BenchmarkCompression/none/batch=1-8                56662             85501 ns/op          233172 B/op         28 allocs/op
BenchmarkCompression/gzip/batch=1-8                27688             64055 ns/op          117560 B/op         35 allocs/op
BenchmarkCompression/zstd/batch=1-8                41965             69071 ns/op          174616 B/op         33 allocs/op
BenchmarkCompression/none/batch=100-8              20131             63991 ns/op          117124 B/op        325 allocs/op
BenchmarkCompression/gzip/batch=100-8               3043            408736 ns/op           54255 B/op        335 allocs/op
BenchmarkCompression/zstd/batch=100-8              10276            120161 ns/op           80178 B/op        330 allocs/op
BenchmarkCompression/none/batch=1000-8              3066            382949 ns/op          323067 B/op       3025 allocs/op
BenchmarkCompression/gzip/batch=1000-8               243           4787768 ns/op          379947 B/op       3038 allocs/op
BenchmarkCompression/zstd/batch=1000-8              1128           1014972 ns/op          391926 B/op       3034 allocs/op
```