### PR TITLE
Fix flaky TestPauses

### DIFF
--- a/client/client_test.go
+++ b/client/client_test.go
@@ -400,9 +400,8 @@ func TestPauses(t *testing.T) {
 	elapsed := []time.Duration{}
 	for i := 0; i < numWorkers; i++ {
 		go func() {
-			then := time.Now()
 			c.Export(context.Background(), batches)
-			elapsed = append(elapsed, time.Since(then)+wait)
+			elapsed = append(elapsed, time.Since(then))
 			wg.Done()
 		}()
 	}


### PR DESCRIPTION
The test was not using the correct starting time for measuring elapsed time. Change to use the start time from the very beginning. The test appears to be fine now.