### PR TITLE
Run benchmarks as github action

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -98,3 +98,32 @@ jobs:
 
       - name: Test
         run: make test
+
+  benchmark:
+    runs-on: ubuntu-latest
+    needs: [setup]
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v3
+
+      - name: Setup Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: 1.18
+
+      - name: Cache Go
+        id: module-cache
+        uses: actions/cache@v3
+        with:
+          path: /home/runner/go/pkg/mod
+          key: go-pkg-mod-${{ runner.os }}-${{ hashFiles('**/go.sum') }}
+
+      - name: Cache Tools
+        id: tool-cache
+        uses: actions/cache@v3
+        with:
+          path: /home/runner/go/bin
+          key: tools-${{ runner.os }}-${{ hashFiles('./internal/tools/go.mod') }}
+
+      - name: Benchmark
+        run: make benchmark

--- a/Makefile
+++ b/Makefile
@@ -102,3 +102,6 @@ install-tools:
 	cd $(TOOLS_MOD_DIR) && go install github.com/google/addlicense
 	cd $(TOOLS_MOD_DIR) && go install github.com/ory/go-acc
 	cd $(TOOLS_MOD_DIR) && go install github.com/pavius/impi/cmd/impi
+
+benchmark:
+	go test ./... -run nosuchtest -benchmem -bench .


### PR DESCRIPTION
The benchmarks were previously broken and we didn't know about it. Make sure they run as part of CI.